### PR TITLE
Fix invalid content type for Gist Fox API + Auth example

### DIFF
--- a/examples/Gist Fox API + Auth.md
+++ b/examples/Gist Fox API + Auth.md
@@ -266,7 +266,7 @@ Where *token* represents an OAuth token and *scopes* is an array of scopes grant
     [Authorization][]
 
 ### Remove an Authorization [DELETE]
-+ Request (application/json)
++ Request
     + Headers
 
             Authorization: Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==


### PR DESCRIPTION
Hi guys, this PR fixes an error which raised when parsing `Gist Fox API + Auth.md`: "Empty request message-body, expected message-body for 'application/json' Content-Type."
