### PR TITLE
The 'pygments' configuration option has been renamed to 'highlighter'

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,6 @@
 safe:         true
 lsi:          false
-pygments:     true
+highlighter:  pygments
 url:          http://apiblueprint.org
 include:      ['favicon.png', 'favicon.ico']
 exclude:      ['*.styl', '*.coffee', 'node_modules', 'package.json', 'app', 'api']


### PR DESCRIPTION
Dealing with...

```
Deprecation: The 'pygments' configuration option has been renamed to 'highlighter'. Please update your config file accordingly. The allowed values are 'rouge', 'pygments' or null.
```

On [this page](https://help.github.com/articles/using-jekyll-with-pages) they have `pygments` in their examples, but at the same time they say GitHub Pages' Jekyll is upgraded often and kept up to date with Jekyll upstream, so GitHub Pages should understand the new option already I guess.
