### PR TITLE
Put HOST after FORMAT

### DIFF
--- a/API Blueprint Specification.md
+++ b/API Blueprint Specification.md
@@ -483,8 +483,8 @@ Metadata keys and its values are tool-specific. Refer to relevant tool documenta
 
 #### Example
 
-    HOST: http://blog.acme.com
     FORMAT: 1A
+    HOST: http://blog.acme.com
 
 ---
 


### PR DESCRIPTION
The @apiaryio editor complained when these were switched.

Which makes sense as the first thing a parser would need to know is the format, then whatever is correct for that format.

Thanks!