### PR TITLE
[Examples] Use `+` instead of `-` for list items

### DIFF
--- a/examples/Gist Fox API + Auth.md
+++ b/examples/Gist Fox API + Auth.md
@@ -24,7 +24,7 @@ HAL links.
 
 + Response 200 (application/hal+json)
     + Headers
-    
+
             Link: <http:/api.gistfox.com/>;rel="self",<http:/api.gistfox.com/gists>;rel="gists",<http:/api.gistfox.com/authorization>;rel="authorization"
 
     + Body
@@ -45,10 +45,10 @@ A single Gist object. The Gist resource is the central resource in the Gist Fox 
 
 The Gist resource has the following attributes: 
 
-- id
-- created_at
-- description
-- content
++ id
++ created_at
++ description
++ content
 
 The states *id* and *created_at* are assigned by the Gist Fox API at the moment of creation. 
 
@@ -103,7 +103,7 @@ Collection of all Gists.
 
 The Gist Collection resource has the following attribute:
 
-- total
++ total
 
 In addition it **embeds** *Gist Resources* in the Gist Fox API.
 
@@ -168,7 +168,7 @@ Star resource represents a Gist starred status.
 
 The Star resource has the following attribute:
 
-- starred
++ starred
 
 + Parameters
     + id (string) ... ID of the gist in the form of a hash
@@ -214,8 +214,8 @@ Authorization Resource represents an authorization granted to the user. You can 
 
 The Authorization Resource has the following attribute:
 
-- token
-- scopes
++ token
++ scopes
 
 Where *token* represents an OAuth token and *scopes* is an array of scopes granted for the given authorization. At this moment the only available scope is `gist_write`.
 

--- a/examples/Gist Fox API.md
+++ b/examples/Gist Fox API.md
@@ -24,7 +24,7 @@ HAL links.
 
 + Response 200 (application/hal+json)
     + Headers
-    
+
             Link: <http:/api.gistfox.com/>;rel="self",<http:/api.gistfox.com/gists>;rel="gists"
 
     + Body
@@ -44,10 +44,10 @@ A single Gist object. The Gist resource is the central resource in the Gist Fox 
 
 The Gist resource has the following attributes: 
 
-- id
-- created_at
-- description
-- content
++ id
++ created_at
++ description
++ content
 
 The states *id* and *created_at* are assigned by the Gist Fox API at the moment of creation. 
 
@@ -102,7 +102,7 @@ Collection of all Gists.
 
 The Gist Collection resource has the following attribute:
 
-- total
++ total
 
 In addition it **embeds** *Gist Resources* in the Gist Fox API.
 
@@ -163,7 +163,7 @@ Star resource represents a Gist starred status.
 
 The Star resource has the following attribute:
 
-- starred
++ starred
 
 
 + Parameters

--- a/examples/Polls API.md
+++ b/examples/Polls API.md
@@ -27,10 +27,10 @@ Resource related to questions in the API.
 
 A Question object has the following attributes:
 
-- question
-- published_at - An ISO8601 date when the question was published.
-- url
-- choices - An array of Choice objects.
++ question
++ published_at - An ISO8601 date when the question was published.
++ url
++ choices - An array of Choice objects.
 
 + Parameters
     + question_id (required, number, `1`) ... ID of the Question in form of an integer
@@ -126,8 +126,8 @@ This action allows you to vote on a question's choice.
 
 You may create your own question using this action. It takes a JSON object containing a question and a collection of answers in the form of choices.
 
-- question (string) - The question
-- choices (array[string]) - A collection of choices.
++ question (string) - The question
++ choices (array[string]) - A collection of choices.
 
 + Request (application/json)
 

--- a/examples/Polls Hypermedia API.md
+++ b/examples/Polls Hypermedia API.md
@@ -221,8 +221,8 @@ This resource does not have any attributes. Instead it offers the initial API af
 
 You may create your own question using this action. It takes a JSON object containing a question and a collection of answers in the form of choices.
 
-- question (string) - The question
-- choices (array[string]) - A collection of choices.
++ question (string) - The question
++ choices (array[string]) - A collection of choices.
 
 + Request (application/json)
 
@@ -384,10 +384,10 @@ Resource related to questions in the API.
 
 A Question object has the following attributes:
 
-- question
-- published_at - An ISO8601 date when the question was published.
-- url
-- choices - An array of Choice objects.
++ question
++ published_at - An ISO8601 date when the question was published.
++ url
++ choices - An array of Choice objects.
 
 + Parameters
     + question_id (required, number, `1`) ... ID of the Question in form of an integer


### PR DESCRIPTION
This adds consistency to how we create list items across all the examples.

/c @zdne 