### PR TITLE
[Examples] Refer to resources group as plural

### DIFF
--- a/Tutorial.md
+++ b/Tutorial.md
@@ -39,7 +39,7 @@ Now it's time to start documenting the API resources. Using the `Group` keyword 
 ```markdown
 # Group Questions
 
-Resource related to questions in the API.
+Resources related to questions in the API.
 ```
 
 ## Resource

--- a/examples/Polls API.md
+++ b/examples/Polls API.md
@@ -21,7 +21,7 @@ It is recommend to follow the “url” link values, [Link](https://tools.ietf.o
 
 ## Group Question
 
-Resource related to questions in the API.
+Resources related to questions in the API.
 
 ## Question [/questions/{question_id}]
 

--- a/examples/Polls Hypermedia API.md
+++ b/examples/Polls Hypermedia API.md
@@ -378,7 +378,7 @@ You may create your own question using this action. It takes a JSON object conta
 
 ## Group Question
 
-Resource related to questions in the API.
+Resources related to questions in the API.
 
 ## Question [/questions/{question_id}]
 


### PR DESCRIPTION
This is from @zdne's feedback on https://github.com/apiaryio/apiary/pull/2203#discussion_r26917091