### PR TITLE
Update API Blueprint Specification.md

### DIFF
--- a/API Blueprint Specification.md
+++ b/API Blueprint Specification.md
@@ -580,7 +580,7 @@ The description of message-body attributes **may** be used to describe message-b
 
         + Body
 
-            { "message" : "Hello World." }
+                { "message" : "Hello World." }
 
 ---
 


### PR DESCRIPTION
Attributes section fix.

I think the body should be indented by 12 space (or 3 tabs) in this case.