### PR TITLE
Remove use of trailing space and hard tabs

### DIFF
--- a/API Blueprint Specification.md
+++ b/API Blueprint Specification.md
@@ -81,7 +81,7 @@ All of the blueprint sections are optional. However, when present, a section **m
 + [`0-1` **API Name & overview** section](#def-api-name-section)
 + [`0+` **Resource** sections](#def-resource-section)
     + [`0-1` **URI Parameters** section](#def-uriparameters-section)
-    + [`0-1` **Attributes** section](#def-attributes-section)    
+    + [`0-1` **Attributes** section](#def-attributes-section)
     + [`0-1` **Model** section](#def-model-section)
         + [`0-1` **Headers** section](#def-headers-section)
         + [`0-1` **Attributes** section](#def-attributes-section)
@@ -593,13 +593,13 @@ The payload defined in this section **may** be referenced in any response or req
 #### Example
 
     # My Resource [/resource]
-    
+
     + Model (text/plain)
 
             Hello World
 
     ## Retrieve My Resource [GET]
-    
+
     + Response 200
 
         [My Resource][]
@@ -680,7 +680,7 @@ Multiple Request and Response nested sections within one transaction example **s
 
     + Attributes
 
-            ...    
+            ...
 
     + Request
 
@@ -888,13 +888,13 @@ Defined by the `Attributes` keyword followed by an optional [MSON Type Definitio
 
 `<Type Definition>` is the type definition of the data structure being described. If the `<Type Definition>` is not specified, an `object` base type is assumed. See [MSON Type Definition][] for details.
 
-##### Example 
+##### Example
 
     + Attributes (object)
 
 #### Description
 This section describes a data structure using the **[Markdown Syntax for Object Notation][MSON] (MSON)**. Based on the parent section, the data structure being described is one of the following:
-    
+
 1. Resource data structure attributes ([Resource section](#def-resource-section))
 2. Action request attributes ([Action section](#def-action-section))
 3. Payload message-body attributes ([Payload section](#def-payload-section))
@@ -902,7 +902,7 @@ This section describes a data structure using the **[Markdown Syntax for Object 
 Data structures defined in this section **may** refer to any arbitrary data structures defined in the [Data Structures section](#def-data-structures) as well as to any data structures defined by a named resource attributes description (see below).
 
 #### Resource Attributes description
-Description of the resource data structure. 
+Description of the resource data structure.
 
 If defined in a named [Resource section](#def-resource-section), this data structure **may** be referenced by other data structures using the resource name.
 
@@ -917,9 +917,9 @@ If defined in a named [Resource section](#def-resource-section), this data struc
         + author: john@appleseed.com (string) - Author of the blog post
 
 > **NOTE:** This data structure can be later referred as:
-> 
+>
 >     + Attributes (Blog Post)
-> 
+>
 
 #### Action Attributes description
 Description of the default request message-body data structure.
@@ -932,7 +932,7 @@ If defined, all the [Request sections](#def-request-section) of the respective [
 
     + Attributes
         + message (string) - The blog post article
-        + author: john@appleseed.com (string) - Author of the blog post        
+        + author: john@appleseed.com (string) - Author of the blog post
 
     + Request (application/json)
 
@@ -1032,7 +1032,7 @@ Defined by the `Data Structures` keyword.
     # Data Structures
 
 #### Description
-This section holds arbitrary data structures definitions defined in the form of [MSON Named Types][]. 
+This section holds arbitrary data structures definitions defined in the form of [MSON Named Types][].
 
 Data structures defined in this section **may** be used in any [Attributes section][]. Similarly, any data structures defined in a [Attributes section][] of a named [Resource Section][] **may** be used in a data structure definition.
 
@@ -1053,7 +1053,7 @@ Refer to the [MSON][] specification for full details on how to define an MSON Na
     + email: john@appleseed.com
 
 
-#### Example reusing Data Structure in Resource 
+#### Example reusing Data Structure in Resource
 
     # User [/user]
 
@@ -1108,9 +1108,9 @@ This section specifies a [link relation type](https://tools.ietf.org/html/rfc598
 
     + Relation: task
     + Response 200
-    
+
             { ... }
-    
+
     ## Delete Task [DELETE]
 
     + Relation: delete

--- a/Glossary of Terms.md
+++ b/Glossary of Terms.md
@@ -6,9 +6,9 @@ A brief list of terms as used in the [API Blueprint](http://apiblueprint.org) co
 
 <a name="def-action"></a>
 ### Action
-An **HTTP transaction** (a request-response transaction). 
+An **HTTP transaction** (a request-response transaction).
 
-Actions are specified by an [HTTP request method](#def-method) within a [resource](#def-resource). 
+Actions are specified by an [HTTP request method](#def-method) within a [resource](#def-resource).
 
 <a name="def-api"></a>
 ### API
@@ -52,14 +52,14 @@ An **HTTP transaction message**.
 
 <a name="def-message-body"></a>
 ### Message body
-An [**asset**](#def-asset) representing [**HTTP transaction message body**](http://en.wikipedia.org/wiki/HTTP_body_data). 
+An [**asset**](#def-asset) representing [**HTTP transaction message body**](http://en.wikipedia.org/wiki/HTTP_body_data).
 
 <a name="def-message-header"></a>
 ### Message header
-An [**asset**](#def-asset) representing [**HTTP transaction message header**](http://en.wikipedia.org/wiki/List_of_HTTP_header_fields). 
+An [**asset**](#def-asset) representing [**HTTP transaction message header**](http://en.wikipedia.org/wiki/List_of_HTTP_header_fields).
 <a name="def-parameter"></a>
 ### Parameter
-An [**URI template**](#def-uri-template) **variable**. 
+An [**URI template**](#def-uri-template) **variable**.
 
 <a name="def-payload"></a>
 ### Payload

--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ It is the task for the API Blueprint parser – [Drafter][] or one of its langua
 
 If you are interested in building tools for API Blueprint or just to integrate it with your workflow check out the [Developing tools for API Blueprint](https://github.com/apiaryio/api-blueprint/wiki/Developing-tools-for-API-Blueprint).
 
-## Media Type 
-The media type for API Blueprint is `text/vnd.apiblueprint+markdown`. 
+## Media Type
+The media type for API Blueprint is `text/vnd.apiblueprint+markdown`.
 
 ## Learn more
 + [Tutorial](Tutorial.md)

--- a/examples/01. Simplest API.md
+++ b/examples/01. Simplest API.md
@@ -1,10 +1,10 @@
 FORMAT: 1A
 
 # The Simplest API
-This is one of the simplest APIs written in the **API Blueprint**. 
+This is one of the simplest APIs written in the **API Blueprint**.
 One plain resource combined with a method and that's it! We will explain what is going on in the next installment - [Resource and Actions](02.%20Resource%20and%20Actions.md).
 
-**Note:** As we progress through the examples, do not also forget to view the [Raw](https://raw.github.com/apiaryio/api-blueprint/master/examples/01.%20Simplest%20API.md) code to see what is really going on in the API Blueprint, as opposed to just seeing the output of the Github Markdown parser. 
+**Note:** As we progress through the examples, do not also forget to view the [Raw](https://raw.github.com/apiaryio/api-blueprint/master/examples/01.%20Simplest%20API.md) code to see what is really going on in the API Blueprint, as opposed to just seeing the output of the Github Markdown parser.
 
 Also please keep in mind that every single example in this course is a **real API Blueprint** and as such you can **parse** it with the [API Blueprint parser](https://github.com/apiaryio/drafter) or one of its [bindings](https://github.com/apiaryio/drafter#bindings).
 
@@ -14,5 +14,5 @@ Also please keep in mind that every single example in this course is a **real AP
 
 # GET /message
 + Response 200 (text/plain)
-    
+
         Hello World!

--- a/examples/02. Resource and Actions.md
+++ b/examples/02. Resource and Actions.md
@@ -4,16 +4,16 @@ FORMAT: 1A
 This API example demonstrates how to define a resource with multiple actions.
 
 ## API Blueprint
-+ [Previous: The Simplest API](01.%20Simplest%20API.md) 
++ [Previous: The Simplest API](01.%20Simplest%20API.md)
 + [This: Raw API Blueprint](https://raw.github.com/apiaryio/api-blueprint/master/examples/02.%20Resource%20and%20Actions.md)
 + [Next: Named Resource and Actions](03.%20Named%20Resource%20and%20Actions.md)
 
 # /message
 This is our [resource](http://www.w3.org/TR/di-gloss/#def-resource). It is defined by its [URI](http://www.w3.org/TR/di-gloss/#def-uniform-resource-identifier) or, more precisely, by its [URI Template](http://tools.ietf.org/html/rfc6570).
 
-This resource has no actions specified but we will fix that soon. 
+This resource has no actions specified but we will fix that soon.
 
-## GET 
+## GET
 Here we define an action using the `GET` [HTTP request method](http://www.w3schools.com/tags/ref_httpmethods.asp) for our resource `/message`.
 
 As with every good action it should return a [response](http://www.w3.org/TR/di-gloss/#def-http-response). A response always bears a status code. Code 200 is great as it means all is green. Responding with some data can be a great idea as well so let's add a plain text message to our response.
@@ -21,12 +21,12 @@ As with every good action it should return a [response](http://www.w3.org/TR/di-
 + Response 200 (text/plain)
 
         Hello World!
-        
-## PUT 
+
+## PUT
 OK, let's add another action. This time to put new data to our resource (essentially an update action). We will need to send something in a [request](http://www.w3.org/TR/di-gloss/#def-http-request) and then send a response back confirming the posting was a success (HTTP Status Code 204 ~ Resource updated successfully, no content is returned).
 
 + Request (text/plain)
 
-        All your base are belong to us. 
-        
+        All your base are belong to us.
+
 + Response 204

--- a/examples/03. Named Resource and Actions.md
+++ b/examples/03. Named Resource and Actions.md
@@ -1,6 +1,6 @@
 FORMAT: 1A
 
-# Named Resource and Actions API 
+# Named Resource and Actions API
 This API example demonstrates how to name a resource and its actions, to give the reader a better idea about what the resource is used for.
 
 ## API Blueprint
@@ -9,7 +9,7 @@ This API example demonstrates how to name a resource and its actions, to give th
 + [Next: Grouping Resources](04.%20Grouping%20Resources.md)
 
 # My Message [/message]
-OK, `My Message` probably isn't the best name for our resource but it will do for now. Note the URI `/message` is enclosed in square brackets. 
+OK, `My Message` probably isn't the best name for our resource but it will do for now. Note the URI `/message` is enclosed in square brackets.
 
 ## Retrieve a Message [GET]
 Now this is informative! No extra explanation needed here. This action clearly retrieves the message.
@@ -17,12 +17,12 @@ Now this is informative! No extra explanation needed here. This action clearly r
 + Response 200 (text/plain)
 
         Hello World!
-        
+
 ## Update a Message [PUT]
 `Update a message` - nice and simple naming is the best way to go.
 
 + Request (text/plain)
 
         All your base are belong to us.
-        
+
 + Response 204

--- a/examples/04. Grouping Resources.md
+++ b/examples/04. Grouping Resources.md
@@ -22,13 +22,13 @@ Any following resource definition is considered to be a part of this group until
 + Response 200 (text/plain)
 
         Hello World!
-        
+
 ### Update a Message [PUT]
 
 + Request (text/plain)
 
         All your base are belong to us.
-        
+
 + Response 204
 
 # Group Users

--- a/examples/05. Responses.md
+++ b/examples/05. Responses.md
@@ -14,7 +14,7 @@ Group of all messages-related resources.
 ## My Message [/message]
 
 ### Retrieve a Message [GET]
-This action has **two** responses defined: One returing a plain text and the other a JSON representation of our resource. Both has the same HTTP status code. Also both responses bear additional information in the form of a custom HTTP header. Note that both responses have set the `Content-Type` HTTP header just by specifying `(text/plain)` or `(application/json)` in their respective signatures. 
+This action has **two** responses defined: One returing a plain text and the other a JSON representation of our resource. Both has the same HTTP status code. Also both responses bear additional information in the form of a custom HTTP header. Note that both responses have set the `Content-Type` HTTP header just by specifying `(text/plain)` or `(application/json)` in their respective signatures.
 
 + Response 200 (text/plain)
 
@@ -41,5 +41,5 @@ This action has **two** responses defined: One returing a plain text and the oth
 + Request (text/plain)
 
         All your base are belong to us.
-        
+
 + Response 204

--- a/examples/06. Requests.md
+++ b/examples/06. Requests.md
@@ -14,10 +14,10 @@ Group of all messages-related resources.
 ## My Message [/message]
 
 ### Retrieve a Message [GET]
-In API Blueprint requests can hold exactly the same kind of information and can be described by exactly the same structure as responses, only with different signature – using the `Request` keyword. The string that follows after the `Request` keyword is a request identifier. Again, using an explanatory and simple naming is the best way to go. 
+In API Blueprint requests can hold exactly the same kind of information and can be described by exactly the same structure as responses, only with different signature – using the `Request` keyword. The string that follows after the `Request` keyword is a request identifier. Again, using an explanatory and simple naming is the best way to go.
 
 + Request Plain Text Message
-    
+
     + Headers
 
             Accept: text/plain
@@ -33,7 +33,7 @@ In API Blueprint requests can hold exactly the same kind of information and can 
             Hello World!
 
 + Request JSON Message
-    
+
     + Headers
 
             Accept: application/json
@@ -46,7 +46,7 @@ In API Blueprint requests can hold exactly the same kind of information and can 
 
     + Body
 
-            { "message": "Hello World!" }      
+            { "message": "Hello World!" }
 
 ### Update a Message [PUT]
 

--- a/examples/07. Parameters.md
+++ b/examples/07. Parameters.md
@@ -1,9 +1,9 @@
 FORMAT: 1A
 
 # Parameters API
-In this installment of the API Blueprint course we will discuss how to describe URI parameters. 
+In this installment of the API Blueprint course we will discuss how to describe URI parameters.
 
-But first let's add more messages to our system. For that we would need introduce an message identifier – id. This id will be our parameter when communicating with our API about messages. 
+But first let's add more messages to our system. For that we would need introduce an message identifier – id. This id will be our parameter when communicating with our API about messages.
 
 ## API Blueprint
 + [Previous: Requests](06.%20Requests.md)
@@ -14,7 +14,7 @@ But first let's add more messages to our system. For that we would need introduc
 Group of all messages-related resources.
 
 ## My Message [/message/{id}]
-Here we have added the message `id` parameter as an [URI Template variable](http://tools.ietf.org/html/rfc6570) in the Message resource's URI. 
+Here we have added the message `id` parameter as an [URI Template variable](http://tools.ietf.org/html/rfc6570) in the Message resource's URI.
 Note the parameter name `id` is enclosed in curly brackets. We will discuss this parameter in the `Parameters` section below, where we will also set its example value to `1` and declare it of an arbitrary 'number' type.
 
 + Parameters
@@ -24,7 +24,7 @@ Note the parameter name `id` is enclosed in curly brackets. We will discuss this
 ### Retrieve a Message [GET]
 
 + Request Plain Text Message
-    
+
     + Headers
 
             Accept: text/plain
@@ -40,7 +40,7 @@ Note the parameter name `id` is enclosed in curly brackets. We will discuss this
             Hello World!
 
 + Request JSON Message
-    
+
     + Headers
 
             Accept: application/json
@@ -53,10 +53,10 @@ Note the parameter name `id` is enclosed in curly brackets. We will discuss this
 
     + Body
 
-            { 
+            {
               "id": 1,
-              "message": "Hello World!" 
-            }      
+              "message": "Hello World!"
+            }
 
 ### Update a Message [PUT]
 
@@ -74,7 +74,7 @@ Note the parameter name `id` is enclosed in curly brackets. We will discuss this
 A resource representing all of my messages in the system.
 
 We have added the query URI template parameter - `limit`. This parameter is used for limiting the number of results returned by some actions on this resource. It does not affect every possible action of this resource therefore we will discuss it only at the particular action level below.
- 
+
 ### Retrieve all Messages [GET]
 
 + Parameters
@@ -83,7 +83,7 @@ We have added the query URI template parameter - `limit`. This parameter is used
         + Default: `20`
 
 + Response 200 (application/json)
- 
+
         [
           {
             "id": 1,

--- a/examples/09. Advanced Attributes.md
+++ b/examples/09. Advanced Attributes.md
@@ -1,7 +1,7 @@
 FORMAT: 1A
 
 # Advanced Attributes API
-Improving the previous [Attributes](08.%20Attributes.md) description example, this API example describes the `Coupon` resource attributes (data structure) regardless of the serialization format. These attributes can be later referenced using the resource name 
+Improving the previous [Attributes](08.%20Attributes.md) description example, this API example describes the `Coupon` resource attributes (data structure) regardless of the serialization format. These attributes can be later referenced using the resource name
 
 These attributes are then reused in the `Retrieve a Coupon` action. Since they describe the complete message, no explicit JSON body example is needed.
 

--- a/examples/10. Data Structures.md
+++ b/examples/10. Data Structures.md
@@ -1,7 +1,7 @@
 FORMAT: 1A
 
 # Data Structures API
-Following [Advanced Attributes](09.%20Advanced%20Attributes.md), this example demonstrates defining arbitrary data structure to be reused by various attribute descriptions. 
+Following [Advanced Attributes](09.%20Advanced%20Attributes.md), this example demonstrates defining arbitrary data structure to be reused by various attribute descriptions.
 
 Since a portion of the `Coupon` data structure is shared between the `Coupon` definition itself and the `Create a Coupon` action, it was separated into a `Coupon Base` data structure in the `Data Strucutes` API Blueprint Section. Doing so enables us to reuse it as a base-type of other attribute definitions.
 

--- a/examples/11. Resource Model.md
+++ b/examples/11. Resource Model.md
@@ -1,7 +1,7 @@
 FORMAT: 1A
 
 # Resource Model API
-Resource model is a [resource manifestation](http://www.w3.org/TR/di-gloss/#def-resource-manifestation). One particular representation of your resource. 
+Resource model is a [resource manifestation](http://www.w3.org/TR/di-gloss/#def-resource-manifestation). One particular representation of your resource.
 
 Furthermore, in API Blueprint, any `resource model` you have defined can be referenced in a request or response section, saving you lots of time maintaining your API blueprint. You simply define a resource model as any payload (e. g. [request](https://github.com/apiaryio/api-blueprint/blob/master/examples/06.%20Requests.md) or [response](https://github.com/apiaryio/api-blueprint/blob/master/examples/5.%20Responses.md)) and then reference it later where you would normally write a `request` or `response`.
 
@@ -16,25 +16,25 @@ Group of all messages-related resources.
 ## My Message [/message]
 
 + Model (application/vnd.siren+json)
-  
+
     This is the `application/vnd.siren+json` message resource representation.
 
     + Headers
-    
-            Location: http://api.acme.com/message            
+
+            Location: http://api.acme.com/message
 
     + Body
 
             {
               "class": [ "message" ],
-              "properties": { 
-                    "message": "Hello World!" 
+              "properties": {
+                    "message": "Hello World!"
               },
               "links": [
                     { "rel": "self" , "href": "/message" }
               ]
             }
-    
+
 ### Retrieve a Message [GET]
 At this point we will utilize our `Message` resource model and reference it in `Response 200`.
 

--- a/examples/Gist Fox API + Auth.md
+++ b/examples/Gist Fox API + Auth.md
@@ -17,7 +17,7 @@ The common [HTTP Response Status Codes](https://github.com/for-GET/know-your-htt
 # Gist Fox API Root [/]
 Gist Fox API entry point.
 
-This resource does not have any attributes. Instead it offers the initial API affordances in the form of the HTTP Link header and 
+This resource does not have any attributes. Instead it offers the initial API affordances in the form of the HTTP Link header and
 HAL links.
 
 ## Retrieve the Entry Point [GET]
@@ -43,14 +43,14 @@ Gist-related resources of *Gist Fox API*.
 ## Gist [/gists/{id}{?access_token}]
 A single Gist object. The Gist resource is the central resource in the Gist Fox API. It represents one paste - a single text note.
 
-The Gist resource has the following attributes: 
+The Gist resource has the following attributes:
 
 + id
 + created_at
 + description
 + content
 
-The states *id* and *created_at* are assigned by the Gist Fox API at the moment of creation. 
+The states *id* and *created_at* are assigned by the Gist Fox API at the moment of creation.
 
 + Parameters
     + id (string) - ID of the Gist in the form of a hash.
@@ -79,7 +79,7 @@ The states *id* and *created_at* are assigned by the Gist Fox API at the moment 
 
 ### Retrieve a Single Gist [GET]
 + Response 200
-    
+
     [Gist][]
 
 ### Edit a Gist [PATCH]
@@ -92,7 +92,7 @@ To update a Gist send a JSON with updated value for one or more of the Gist reso
         }
 
 + Response 200
-    
+
     [Gist][]
 
 ### Delete a Gist [DELETE]
@@ -145,9 +145,9 @@ In addition it **embeds** *Gist Resources* in the Gist Fox API.
     [Gists Collection][]
 
 ### Create a Gist [POST]
-To create a new Gist simply provide a JSON hash of the *description* and *content* attributes for the new Gist. 
+To create a new Gist simply provide a JSON hash of the *description* and *content* attributes for the new Gist.
 
-This action requires an `access_token` with `gist_write` scope. 
+This action requires an `access_token` with `gist_write` scope.
 
 + Parameters
     + access_token (string, optional) - Gist Fox API access token.
@@ -164,7 +164,7 @@ This action requires an `access_token` with `gist_write` scope.
     [Gist][]
 
 ## Star [/gists/{id}/star{?access_token}]
-Star resource represents a Gist starred status. 
+Star resource represents a Gist starred status.
 
 The Star resource has the following attribute:
 
@@ -192,12 +192,12 @@ The Star resource has the following attribute:
             }
 
 ### Star a Gist [PUT]
-This action requires an `access_token` with `gist_write` scope. 
+This action requires an `access_token` with `gist_write` scope.
 
 + Response 204
 
 ### Unstar a Gist [DELETE]
-This action requires an `access_token` with `gist_write` scope. 
+This action requires an `access_token` with `gist_write` scope.
 
 + Response 204
 
@@ -263,7 +263,7 @@ Where *token* represents an OAuth token and *scopes* is an array of scopes grant
 
 + Response 201
 
-    [Authorization][]
+        [Authorization][]
 
 ### Remove an Authorization [DELETE]
 + Request
@@ -271,4 +271,4 @@ Where *token* represents an OAuth token and *scopes* is an array of scopes grant
 
             Authorization: Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==
 
-+ Response 204    
++ Response 204

--- a/examples/Gist Fox API.md
+++ b/examples/Gist Fox API.md
@@ -17,7 +17,7 @@ The common [HTTP Response Status Codes](https://github.com/for-GET/know-your-htt
 # Gist Fox API Root [/]
 Gist Fox API entry point.
 
-This resource does not have any attributes. Instead it offers the initial API affordances in the form of the HTTP Link header and 
+This resource does not have any attributes. Instead it offers the initial API affordances in the form of the HTTP Link header and
 HAL links.
 
 ## Retrieve the Entry Point [GET]
@@ -42,14 +42,14 @@ Gist-related resources of *Gist Fox API*.
 ## Gist [/gists/{id}]
 A single Gist object. The Gist resource is the central resource in the Gist Fox API. It represents one paste - a single text note.
 
-The Gist resource has the following attributes: 
+The Gist resource has the following attributes:
 
 + id
 + created_at
 + description
 + content
 
-The states *id* and *created_at* are assigned by the Gist Fox API at the moment of creation. 
+The states *id* and *created_at* are assigned by the Gist Fox API at the moment of creation.
 
 
 + Parameters
@@ -78,7 +78,7 @@ The states *id* and *created_at* are assigned by the Gist Fox API at the moment 
 
 ### Retrieve a Single Gist [GET]
 + Response 200
-    
+
     [Gist][]
 
 ### Edit a Gist [PATCH]
@@ -91,7 +91,7 @@ To update a Gist send a JSON with updated value for one or more of the Gist reso
         }
 
 + Response 200
-    
+
     [Gist][]
 
 ### Delete a Gist [DELETE]
@@ -145,7 +145,7 @@ In addition it **embeds** *Gist Resources* in the Gist Fox API.
     [Gists Collection][]
 
 ### Create a Gist [POST]
-To create a new Gist simply provide a JSON hash of the *description* and *content* attributes for the new Gist. 
+To create a new Gist simply provide a JSON hash of the *description* and *content* attributes for the new Gist.
 
 + Request (application/json)
 
@@ -159,7 +159,7 @@ To create a new Gist simply provide a JSON hash of the *description* and *conten
     [Gist][]
 
 ## Star [/gists/{id}/star]
-Star resource represents a Gist starred status. 
+Star resource represents a Gist starred status.
 
 The Star resource has the following attribute:
 

--- a/examples/Real World API.md
+++ b/examples/Real World API.md
@@ -16,7 +16,7 @@ A Post is the other central object utilized by the App.net Stream API. It has ri
     + post_id: `1` (string) - The id of the Post.
 
 + Model (application/json)
-    
+
     ```js
     {
         "data": {
@@ -70,7 +70,7 @@ A Post is the other central object utilized by the App.net Stream API. It has ri
 Returns a specific Post.
 
 + Response 200
-    
+
     [Post][]
 
 ### Delete a Post [DELETE]
@@ -82,7 +82,7 @@ Delete a Post. The current user must be the same user who created the Post. It r
 A Collection of posts.
 
 + Model (application/json)
-    
+
     ```js
     {
         "data": [
@@ -102,25 +102,25 @@ A Collection of posts.
         "meta": {
             "code": 200,
         }
-    }    
+    }
     ```
 
 ### Create a Post [POST]
 Create a new Post object. Mentions and hashtags will be parsed out of the post text, as will bare URLs...
 
 + Request
-    
+
     [Post][]
 
 + Response 201
-    
+
     [Post][]
 
 ### Retrieve all Posts [GET]
-Retrieves all posts. 
+Retrieves all posts.
 
 + Response 200
-    
+
     [Posts Collection][]
 
 ## Stars [/stream/0/posts/{post_id}/star]
@@ -135,12 +135,12 @@ Save a given Post to the current User’s stars. This is just a “save” actio
 *Note: A repost cannot be starred. Please star the parent Post.*
 
 + Response 200
-    
+
     [Post][]
 
 ### Unstar a Post [DELETE]
 Remove a Star from a Post.
 
 + Response 200
-        
+
     [Post][]


### PR DESCRIPTION
This pull request removes trailing spaces and use of hard tabs across all of the markdown documents in this repository.

I was playing around with mdl ([Markdown Lint](https://github.com/mivok/markdownlint)) which pointed all these out.

MDL now passes (but had to disable a bunch of [rules](https://github.com/mivok/markdownlint/blob/master/docs/RULES.md)):

```ruby
# .mdlrc
rules "~MD004",  # Unordered list style
      "~MD007",  # Unordered list indentation
      "~MD012",  # Multiple consecutive blank lines
      "~MD013",  # Line Length
      "~MD022",  # Headers should be surrounded by blank lines
      "~MD032",  # Lists should be surrounded by blank lines
      "~MD033",  # Inline HTML
      "~MD024",  # Multiple headers with the same content
      "~MD026",  # Trailing punctuation in header
      "~MD027",  # Multiple spaces after blockquote symbol
      "~MD028",  # Blank line inside blockquote
      "~MD029",  # Ordered list item prefix
      "~MD031",  # Fenced code blocks should be surrounded by blank lines
      "~MD034",  # Base URL used
      "~MD036"   # Emphasis used instead of a header
```