### PR TITLE
[Examples] Align parameter syntax for the Polls example API

### DIFF
--- a/examples/Polls API.md
+++ b/examples/Polls API.md
@@ -33,7 +33,7 @@ A Question object has the following attributes:
 + choices - An array of Choice objects.
 
 + Parameters
-    + question_id (required, number, `1`) ... ID of the Question in form of an integer
+    + question_id: 1 (required, number) - ID of the Question in form of an integer
 
 ### View a Questions Detail [GET]
 
@@ -67,8 +67,8 @@ A Question object has the following attributes:
 ## Choice [/questions/{question_id}/choices/{choice_id}]
 
 + Parameters
-    + question_id (required, number, `1`) ... ID of the Question in form of an integer
-    + choice_id (required, number, `1`) ... ID of the Choice in form of an integer
+    + question_id: 1 (required, number) - ID of the Question in form of an integer
+    + choice_id: 1 (required, number) - ID of the Choice in form of an integer
 
 ### Vote on a Choice [POST]
 
@@ -83,7 +83,7 @@ This action allows you to vote on a question's choice.
 ## Questions Collection [/questions{?page}]
 
 + Parameters
-    + page (optional, number, `1`) ... The page of questions to return
+    + page: 1 (optional, number) - The page of questions to return
 
 ### List All Questions [GET]
 

--- a/examples/Polls Hypermedia API.md
+++ b/examples/Polls Hypermedia API.md
@@ -33,7 +33,7 @@ This resource does not have any attributes. Instead it offers the initial API af
 ## Questions Collection [/questions{?page}]
 
 + Parameters
-    + page (optional, number, `1`) ... The page of questions to return
+    + page: 1 (optional, number) - The page of questions to return
 
 ### List All Questions [GET]
 
@@ -394,7 +394,7 @@ A Question object has the following attributes:
 + choices - An array of Choice objects.
 
 + Parameters
-    + question_id (required, number, `1`) ... ID of the Question in form of an integer
+    + question_id: 1 (required, number) - ID of the Question in form of an integer
 
 ### View a Questions Detail [GET]
 
@@ -543,8 +543,8 @@ A Question object has the following attributes:
 ## Choice [/questions/{question_id}/choices/{choice_id}]
 
 + Parameters
-    + question_id (required, number, `1`) ... ID of the Question in form of an integer
-    + choice_id (required, number, `1`) ... ID of the Choice in form of an integer
+    + question_id: 1 (required, number) - ID of the Question in form of an integer
+    + choice_id: 1 (required, number) - ID of the Choice in form of an integer
 
 ### View a Choice Detail [GET]
 


### PR DESCRIPTION
Some of these examples we're still using the old syntax for parameters, this pull request updates them to use the new MSON aligned syntax.