### PR TITLE
Authentication syntax proposal

### DIFF
--- a/API Blueprint Specification.md
+++ b/API Blueprint Specification.md
@@ -98,6 +98,7 @@ All of the blueprint sections are optional. However, when present, a section **m
         + [`0-1` **URI Parameters** section](#def-uriparameters-section)
         + [`0-1` **Attributes** section](#def-attributes-section)
         + [`0+` **Request** sections](#def-request-section)
+            + [`0-1` **Authentication** section](#def-authentication-section)
             + [`0-1` **Headers** section](#def-headers-section)
             + [`0-1` **Attributes** section](#def-attributes-section)
             + [`0-1` **Body** section](#def-body-section)
@@ -489,7 +490,7 @@ Name and description of the API
 
 <a name="def-authentication-section"></a>
 ## Authentication section
-- **Parent sections:** none, [Action section](#def-action-section)
+- **Parent sections:** none, [Action section](#def-action-section), [Request section](#def-request-section)
 - **Nested sections:** [`1` Authentication schemes section](#def-authenticationschemes-section), [`1` Response section](#def-response-section)
 - **Markdown entity:** header, list
 - **Inherits from**: none
@@ -505,7 +506,7 @@ Defined by the `Authentication` keyword in Markdown list entity followed by opti
 
     + Authentication: <list>
 
-> **NOTE:** The second notation is only used when the parent section is an [Action section](#def-action-section).
+> **NOTE:** The second notation is only used when the parent section is either an [Action section](#def-action-section) or a [Request section](#def-request-section).
 
 #### Description
 Based on the parent section, the usage of this section differs as shown below.
@@ -532,14 +533,14 @@ The [Authentication schemes section](#def-authenticationschemes-section) defines
               "type": "error"
             }
 
-#### Action Authentication section
-Description of the authentication support for a particular action in the API.
+#### Request Authentication section
+Description of the request level authentication settings.
 
-If defined, the respecitve action of the [Action section](#def-action-section) in the API can only be accessed using a vaild authentication scheme. If a list of scheme names is provided after the `Authentication` keyword, the respective action in the API does not allow other authentication schemes.
+If defined inside a [Request section](#def-request-section) of a HTTP transaction example, it implies that the API's response will be the same as the respective response when a valid authentication is sent along with the above mentioned request. This allows another HTTP transaction example to be specified for the cases where an authentication is not needed.
 
 This section **should** not have any nested sections.
 
-##### Example
+If a list of scheme names is provided after the `Authentication` keyword, then only those particular authentication schemes will be allowed for the respective HTTP transaction.
 
 ```
 + Authentication
@@ -548,6 +549,44 @@ This section **should** not have any nested sections.
 ```
 + Authentication: basic, token
 ```
+
+##### Example
+
+    ## GET /users/bond
+
+    + Response 200 (application/json)
+
+            {
+                "username": "bond"
+            }
+
+    + Request
+        + Authentication
+
+    + Response 200 (application/json)
+
+            {
+                "username": "bond",
+                "email": "james@bo.nd",
+                "bio": "I am 007"
+            }
+
+#### Action Authentication section
+Description of the action level authentication settings.
+
+If defined, all the [Request sections](#def-requestion-section) of the respective [Action section](#def-action-section) inherits the authentication settings unless specified otherwise.
+
+This section **should** not have any nested sections.
+
+##### Example
+
+    ## Retrieve User [GET]
+
+    + Authentication
+
+    + Response 200
+
+            { ... }
 
 ---
 
@@ -585,7 +624,7 @@ Where:
 
 Description of the base authentication schemes inherently defined in API Blueprint are defined below.
 
-#### Basic Auth Scheme
+#### Basic Authentication Scheme
 This is the [Basic Authentication Scheme](http://tools.ietf.org/html/rfc2617#section-2) as specified in [RFC 2617](http://tools.ietf.org/html/rfc2617).
 
 The customizable options for this scheme are:
@@ -599,7 +638,7 @@ The customizable options for this scheme are:
         + sample_username: `bond`
         + sample_password: `Iam007`
 
-#### Oauth2 Auth Scheme
+#### Oauth2 Authentication Scheme
 This scheme uses the [Oauth2 Authorization Framework](http://tools.ietf.org/html/rfc6749) specified in [RFC 6749](http://tools.ietf.org/html/rfc6749) to get an authorization grant and uses it access the API.
 
 The customizable options for this scheme are:
@@ -609,6 +648,7 @@ The customizable options for this scheme are:
 + `token_header_keyword` represents the string used instead of "Bearer" in "Authorization" header field according to [RFC 6750](http://tools.ietf.org/html/rfc6750#section-2.1). "Bearer" is the **default**.
 + `token_body_keyword` represents the parameter name used instead of "access_token" in the body of an API request according to [RFC 6750](http://tools.ietf.org/html/rfc6750#section-2.2). "access_token" is the **default**.
 + `token_query_keyword` represents the parameter name used instead of "access_token" in the query of an API request according to [RFC 6750](http://tools.ietf.org/html/rfc6750#section-2.3). "access_token" is the **default**.
++ `sample_token` represens a sample access token value. "sample_token" is the **default**.
 
 ##### Example
 
@@ -616,12 +656,13 @@ The customizable options for this scheme are:
         + access_token_endpoint: `/token`
         + token_header_keyword: `token`
 
-#### Bearer Auth Scheme
+#### Bearer Authentication Scheme
 This scheme is popularly used when API consumers has access to their own unique access token which can be used as a bearer token as specified in [RFC 6750](https://tools.ietf.org/html/rfc6750#section-2.1).
 
 The customizable options for this scheme are:
 
 + `keyword` represents the string used instead of "Bearer" in the "Authorization" header field according to [RFC 6750](https://tools.ietf.org/html/rfc6750#section-2.1). "Bearer" is the **default**.
++ `sample_token` represents a sample bearer token value. "sample_token" is the **default**.
 
 ##### Example
 
@@ -897,7 +938,7 @@ Multiple Request and Response nested sections within one transaction example **s
 <a name="def-request-section"></a>
 ## Request section
 - **Parent sections:** [Action section](#def-action-section)
-- **Nested sections:** [Refer to payload section](#def-payload-section)
+- **Nested sections:** [Refer to payload section](#def-payload-section), [`0-1` Authentication section](#def-authentication-section)
 - **Markdown entity:** list
 - **Inherits from**: [Payload section](#def-payload-section)
 

--- a/API Blueprint Specification.md
+++ b/API Blueprint Specification.md
@@ -46,7 +46,7 @@ Version: 1A8
 + [Data Structures section](#def-data-structures)
 + [Relation section](#def-relation-section)
 + [Authentication section](#def-authentication-section)
-+ [Authentication schemes section](#def-authenticationschemes-section)
++ [Authentication Schemes section](#def-authentication-schemes-section)
 + [Authenticated section](#def-authenticated-section)
 
 ## [III. Appendix](#def-appendix)
@@ -82,7 +82,7 @@ All of the blueprint sections are optional. However, when present, a section **m
 + [`0-1` **Metadata** section](#def-metadata-section)
 + [`0-1` **API Name & overview** section](#def-api-name-section)
 + [`0-1` **Authentication** section](#def-authentication-section)
-    + [`1` **Authentication schemes** section](#def-authenticationschemes-section)
+    + [`1` **Authentication Schemes** section](#def-authentication-schemes-section)
     + [`1` **Response** section](#def-response-section)
 + [`0+` **Resource** sections](#def-resource-section)
     + [`0-1` **Authenticated** section](#def-authenticated-section)
@@ -110,6 +110,7 @@ All of the blueprint sections are optional. However, when present, a section **m
             + [`0-1` **Body** section](#def-body-section)
             + [`0-1` **Schema** section](#def-schema-section)
 + [`0+` **Resource Group** sections](#def-resourcegroup-section)
+    + [`0-1` **Authenticated** section](#def-authenticated-section)
     + [`0+` **Resource** sections](#def-resource-section) (see above)
 + [`0+` **Data Structures** section](#def-data-structures)
 
@@ -493,21 +494,21 @@ Name and description of the API
 <a name="def-authentication-section"></a>
 ## Authentication section
 - **Parent sections:** none
-- **Nested sections:** [`1` Authentication schemes section](#def-authenticationschemes-section), [`1` Response section](#def-response-section)
+- **Nested sections:** [`1` Authentication Schemes section](#def-authentication-schemes-section), [`1` Response section](#def-response-section)
 - **Markdown entity:** header
 - **Inherits from**: none
 
 #### Definition
 Defined by the `Authentication` keyword in Markdown header entity.
 
-    # Authentication
+    ## Authentication
 
 #### Description
 Authentication settings for the whole API.
 
-This section **should** include one [Authentication schemes section](#def-authenticationschemes-section) and one [Response section](#def-response-section).
+This section **should** include one [Authentication Schemes section](#def-authentication-schemes-section) and one [Response section](#def-response-section).
 
-The [Authentication schemes section](#def-authenticationschemes-section) defines all the types of authentication schemes supported by the API. The [Response section](#def-response-section) describes the error message returned in the case of failed authentication.
+The [Authentication Schemes section](#def-authentication-schemes-section) defines all the types of authentication schemes supported by the API. The [Response section](#def-response-section) describes the error message returned in the case of failed authentication.
 
 ##### Example
 
@@ -517,7 +518,7 @@ The [Authentication schemes section](#def-authenticationschemes-section) defines
     + Authentication Schemes
         + ...
 
-    + Response 403 (application/json)
+    + Response 401 (application/json)
 
             {
               "message": "Authentication required",
@@ -526,8 +527,8 @@ The [Authentication schemes section](#def-authenticationschemes-section) defines
 
 ---
 
-<a name="def-authenticationschemes-section"></a>
-## Authentication schemes section
+<a name="def-authentication-schemes-section"></a>
+## Authentication Schemes section
 - **Parent sections:** [Authentication section](#def-authentication-section)
 - **Nested sections:** none
 - **Markdown entity:** list
@@ -559,7 +560,7 @@ Where:
 + `<scheme name>` is the authentication scheme name by which this scheme is represented in [Authenticated section](#def-authenticated-section).
 + `<description>` is any **optional** Markdown-formatted description of the authentication scheme.
 + `<base scheme type>` is the base authentication scheme type (e.g. "Basic Authentication Scheme"). See below for all the available base authentication schemes.
-+ `<customizable option n>` represents a customizable option in the base authentication scheme. It is a [MSON Property Member Declaration][] without the [MSON Type Definition][] where the [MSON Property Name][] represents the name of the option and [MSON Value][] represents the value of the option.
++ `<customizable option n>` represents a customizable option in the base authentication scheme. It is a [MSON Property Member Type][] without the [MSON Type Definition][] where the [MSON Property Name][] represents the name of the option and the value of the property member represents the value of the option.
 
 List of the base authentication schemes supported by API Blueprint are described below.
 
@@ -574,32 +575,32 @@ The customizable options for this scheme are:
 ##### Example
 
     + basic (Basic Authentication Scheme)
-        + example_username: `john`
-        + example_password: `password`
+        + `example_username`: `john`
+        + `example_password`: `password`
 
 #### OAuth2 Authentication Scheme
 This scheme uses the [OAuth2 Authorization Framework](http://tools.ietf.org/html/rfc6749) specified in [RFC 6749](http://tools.ietf.org/html/rfc6749) to get an authorization grant which is then used to access the API.
 
 The customizable options for this scheme are:
 
-+ `oauth_resource_endpoint` is the oauth resource endpoint where the oauth framework resides. Value type is **string**. "/" is the **default**.
++ `resource_endpoint` is the OAuth resource endpoint where the OAuth framework resides. Value type is **string**. "/" is the **default**.
 + `scopes` represents the OAuth scopes which indicate a list of permissions. Value type is **array**. By **default** no scopes are specified.
 + `authorization_endpoint` is the authorization endpoint required for the authorization grant. Value type is **string**. "/authorize" is the **default**.
 + `access_token_endpoint` is the token endpoint used by client to obtain the access token. Value type is **string**. "/access_token" is the **default**.
-+ `revocation_endpoint` is the revocation endpoint used by client to revoke a token. Value type is **string**. "/revoke" is the **default**.
++ `revocation_endpoint` is the revocation endpoint used by client to revoke a token as defined in [RFC 7009](https://tools.ietf.org/html/rfc7009). Value type is **string**.
 + `token_header_keyword` represents the string used instead of "Bearer" in "Authorization" header field according to [RFC 6750](http://tools.ietf.org/html/rfc6750#section-2.1). Value type is **string**. "Bearer" is the **default**.
-+ `token_body_keyword` represents the parameter name used instead of "access_token" in the body of an API request according to [RFC 6750](http://tools.ietf.org/html/rfc6750#section-2.2). Value type is **string**. "access_token" is the **default**.
-+ `token_query_keyword` represents the parameter name used instead of "access_token" in the query of an API request according to [RFC 6750](http://tools.ietf.org/html/rfc6750#section-2.3). Value type is **string**. "access_token" is the **default**.
++ `token_body_keyword` represents the parameter name used instead of "access_token" in the body of an API request according to [RFC 6750](http://tools.ietf.org/html/rfc6750#section-2.2). Value type is **string**.
++ `token_query_keyword` represents the parameter name used instead of "access_token" in the query of an API request according to [RFC 6750](http://tools.ietf.org/html/rfc6750#section-2.3). Value type is **string**.
 + `example_token` represents an example access token value. Value type is **string**. "example_token" is the **default**.
 
-> **NOTE:** The value for `oauth_resource_endpoint` can include hostnames. `authorization_endpoint` and `access_token_endpoint` allow it too only if `oauth_resource_endpoint` is not specified.
+> **NOTE:** The value for `resource_endpoint` can include hostnames. `authorization_endpoint` and `access_token_endpoint` allow it too only if `resource_endpoint` is not specified.
 
 ##### Example
 
     + oauth (OAuth2 Authentication Scheme)
-        + oauth_resource_endpoint: `/oauth`
-        + access_token_endpoint: `/token`
-        + token_header_keyword: `token`
+        + `resource_endpoint`: `/oauth`
+        + `access_token_endpoint`: `/token`
+        + `token_header_keyword`: `token`
         + scopes: read, write, email
 
 #### Bearer Authentication Scheme
@@ -607,13 +608,15 @@ This scheme represents the method of sending a bearer token as specified in [RFC
 
 The customizable options for this scheme are:
 
-+ `keyword` represents the string used instead of "Bearer" in the "Authorization" header field according to [RFC 6750](https://tools.ietf.org/html/rfc6750#section-2.1). Value type is **string**. "Bearer" is the **default**.
++ `token_header_keyword` represents the string used instead of "Bearer" in "Authorization" header field according to [RFC 6750](http://tools.ietf.org/html/rfc6750#section-2.1). Value type is **string**. "Bearer" is the **default**.
++ `token_body_keyword` represents the parameter name used instead of "access_token" in the body of an API request according to [RFC 6750](http://tools.ietf.org/html/rfc6750#section-2.2). Value type is **string**.
++ `token_query_keyword` represents the parameter name used instead of "access_token" in the query of an API request according to [RFC 6750](http://tools.ietf.org/html/rfc6750#section-2.3). Value type is **string**.
 + `example_token` represents an example bearer token value. Value type is **string**. "example_token" is the **default**.
 
 ##### Example
 
     + token (Bearer Authentication Scheme)
-        + keyword: `token`
+        + `token_header_keyword`: `token`
 
 ---
 
@@ -628,18 +631,21 @@ Defined by the `Authenticated` keyword in Markdown list entity followed by optio
 
     + Authenticated: <list>
 
-> **NOTE:** If name of an authentication scheme dervied from `OAuth2 Authentication Scheme` is used, it can optionally have comma seperated list of oauth scopes inside `[]` immediately following it.
+If name of an authentication scheme dervied from `OAuth2 Authentication Scheme` is used, it can optionally have comma seperated list of OAuth scopes inside `[]` immediately following it. If two or more OAuth scopes are using in an authentication setting, then any of the scopes can be used to satisfy the authentication setting.
+
+> **NOTE:** Since each of the OAuth scopes is an [MSON Value][], they should be escaped by backticks if they contain any [MSON][] reserved characters
 
 #### Description
 This section describes an authentication setting. Based on the parent section, the authentication setting being described is one of the following:
 
-1. Resource authentication setting ([Resource section](#def-resource-section))
-2. Action authentication setting ([Action section](#def-action-section))
-3. Request authentication setting ([Request section](#def-request-section))
+1. Resource group authentication setting ([Resource group section](#def-resource-group-section))
+2. Resource authentication setting ([Resource section](#def-resource-section))
+3. Action authentication setting ([Action section](#def-action-section))
+4. Request authentication setting ([Request section](#def-request-section))
 
 The authentication setting for a [Request section](#def-request-section) denotes the authentication needed to be sent along with the request to get the [Response section](#def-response-section) of the respective transaction example.
 
-If the authentication setting contains only the `Authenticated` keyword, the transaction example allows all the authentication schemes described in the [Authentication schemes section](#def-authenticationschemes-section).
+If the authentication setting contains only the `Authenticated` keyword, the transaction example allows all the authentication schemes described in the [Authentication Schemes section](#def-authentication-schemes-section).
 
 ```
 + Authenticated
@@ -654,6 +660,26 @@ If the authentcation setting contains a list of scheme names after the `Authenti
 ```
 + Authenticated: oauth[read, email], token
 ```
+
+#### Resource group Authenticated description
+Description of the resource group authentication setting.
+
+If defined in a [Resource group section](#def-resource-group-section), all the requests of the transaction examples under the resources of this resource group will inherit the authentication setting unless specified otherwise.
+
+##### Example
+
+    # Group Users
+
+    + Authenticated
+
+    ## User [/user]
+    ### Retrieve User [GET]
+
+    + Response 200
+
+            {
+              "username": "john"
+            }
 
 #### Resource Authenticated description
 Description of the resource authentication setting.
@@ -1491,7 +1517,7 @@ With `varone := 42`, `vartwo = hello`, `varthree = 1024` the expansion is `/path
 
 [MSON]: https://github.com/apiaryio/mson
 [MSON Named Types]: https://github.com/apiaryio/mson/blob/master/MSON%20Specification.md#22-named-types
-[MSON Property Member Declaration]: https://github.com/apiaryio/mson/blob/master/MSON%20Specification.md#32-property-member-declaration
+[MSON Property Member Type]: https://github.com/apiaryio/mson/blob/master/MSON%20Specification.md#231-property-member-types
 [MSON Type Definition]: https://github.com/apiaryio/mson/blob/master/MSON%20Specification.md#35-type-definition
 [MSON Property Name]: https://github.com/apiaryio/mson/blob/master/MSON%20Specification.md#321-property-name
 [MSON Value]: https://github.com/apiaryio/mson/blob/master/MSON%20Specification.md#341-value

--- a/API Blueprint Specification.md
+++ b/API Blueprint Specification.md
@@ -30,6 +30,8 @@ Version: 1A8
 ### Section Basics
 + [Metadata section](#def-metadata-section)
 + [API name & overview section](#def-api-name-section)
++ [Authentication section](#def-authentication-section)
++ [Authentication schemes section](#def-authenticationschemes-section)
 + [Resource group section](#def-resourcegroup-section)
 + [Resource section](#def-resource-section)
 + [Resource model section](#def-model-section)
@@ -79,6 +81,9 @@ All of the blueprint sections are optional. However, when present, a section **m
 
 + [`0-1` **Metadata** section](#def-metadata-section)
 + [`0-1` **API Name & overview** section](#def-api-name-section)
++ [`0-1` **Authentication** section](#def-authentication-section)
+    + [`1` **Authentication schemes** section](#def-authenticationschemes-section)
+    + [`1` **Response** section](#def-response-section)
 + [`0+` **Resource** sections](#def-resource-section)
     + [`0-1` **URI Parameters** section](#def-uriparameters-section)
     + [`0-1` **Attributes** section](#def-attributes-section)
@@ -89,6 +94,7 @@ All of the blueprint sections are optional. However, when present, a section **m
         + [`0-1` **Schema** section](#def-schema-section)
     + [`1+` **Action** sections](#def-action-section)
         + [`0-1` **Relation** section](#def-relation-section)
+        + [`0-1` **Authentication** section](#def-authentication-section)
         + [`0-1` **URI Parameters** section](#def-uriparameters-section)
         + [`0-1` **Attributes** section](#def-attributes-section)
         + [`0+` **Request** sections](#def-request-section)
@@ -200,6 +206,7 @@ Following reserved keywords are used in section definitions:
 
 #### Header keywords
 - `Group`
+- `Authentication`
 - `Data Structures`
 - [HTTP methods][httpmethods] (e.g. `GET, POST, PUT, DELETE`...)
 - [URI templates][uritemplate] (e.g. `/resource/{id}`)
@@ -216,6 +223,8 @@ Following reserved keywords are used in section definitions:
 - `Values`
 - `Attribute` & `Attributes`
 - `Relation`
+- `Authentication`
+- `Authentication Schemes`
 
 > **NOTE: Avoid using these keywords in other Markdown headers or lists**
 
@@ -475,6 +484,149 @@ Name and description of the API
 
     # Basic ACME Blog API
     Welcome to the **ACME Blog** API. This API provides access to the **ACME Blog** service.
+
+---
+
+<a name="def-authentication-section"></a>
+## Authentication section
+- **Parent sections:** none, [Action section](#def-action-section)
+- **Nested sections:** [`1` Authentication schemes section](#def-authenticationschemes-section), [`1` Response section](#def-response-section)
+- **Markdown entity:** header, list
+- **Inherits from**: none
+
+#### Definition
+Defined by the `Authentication` keyword in Markdown header entity.
+
+    # Authentication
+
+**-- or --**
+
+Defined by the `Authentication` keyword in Markdown list entity followed by optional comma seperated list of scheme names which is prefixed by a colon.
+
+    + Authentication: <list>
+
+> **NOTE:** The second notation is only used when the parent section is an [Action section](#def-action-section).
+
+#### Description
+Based on the parent section, the usage of this section differs as shown below.
+
+#### API Authentication section
+Description of the authentication support for the whole API.
+
+This section **should** include one [Authentication schemes section](#def-authenticationschemes-section) and one [Response section](#def-response-section).
+
+The [Authentication schemes section](#def-authenticationschemes-section) defines all the types of authentication schemes supported by the API. Where as, the [Response section](#def-response-section) describes the error response given by an authentication protected endpoint when no authentication is provided with the request.
+
+##### Example
+
+    ## Authentication
+    This API supports different kinds of the authentication.
+
+    + Authentication Schemes
+        + ...
+
+    + Response 403 (application/json)
+
+            {
+              "message": "Authentication required",
+              "type": "error"
+            }
+
+#### Action Authentication section
+Description of the authentication support for a particular action in the API.
+
+If defined, the respecitve action of the [Action section](#def-action-section) in the API can only be accessed using a vaild authentication scheme. If a list of scheme names is provided after the `Authentication` keyword, the respective action in the API does not allow other authentication schemes.
+
+This section **should** not have any nested sections.
+
+##### Example
+
+```
++ Authentication
+```
+
+```
++ Authentication: basic, token
+```
+
+---
+
+<a name="def-authenticationschemes-section"></a>
+## Authentication schemes section
+- **Parent sections:** [Authentication section](#def-authentication-section)
+- **Nested sections:** See below
+- **Markdown entity:** list
+- **Inherits from**: none
+
+#### Definition
+Defined by the `Authentication Schemes` keyword.
+
+    + Authentication Schemes
+
+#### Description
+Description of the list of authentication schemes supported by the API.
+
+This section **must** be composed of nested list items only. This section **must not** contain any other elements. Each list item describes a single Authentication scheme.
+
+    + <scheme name> (<base scheme type>) - <description>
+
+        + `<key 1>`: <value 1>
+        + `<key 2>`: <value 2>
+        ...
+        + `<key N>`: <value N>
+
+Where:
+
++ `<scheme name>` is the scheme name as written in [Authentication section](#def-authentication-section) under an [Action section](#def-action-section).
++ `<description>` is any **optional** Markdown-formatted description of the authentication scheme.
++ `<base scheme type>` is the authentication scheme type as expected by the API (e.g. "Basic Auth Scheme"). See below for all the available base authentication schemes.
++ `<key n>` represents a key of an customizable option in the base authentication scheme.
++ `<value n>` represents the value for the option with the key `<key n>`.
+
+Description of the base authentication schemes inherently defined in API Blueprint are defined below.
+
+#### Basic Auth Scheme
+This is the [Basic Authentication Scheme](http://tools.ietf.org/html/rfc2617#section-2) as specified in [RFC 2617](http://tools.ietf.org/html/rfc2617).
+
+The customizable options for this scheme are:
+
++ `sample_username` represents a sample username value. "sample_user" is the **default**.
++ `sample_password` represents a sample password value. "sample_pass" is the **default**.
+
+##### Example
+
+    + basic (Basic Auth Scheme)
+        + sample_username: `bond`
+        + sample_password: `Iam007`
+
+#### Oauth2 Auth Scheme
+This scheme uses the [Oauth2 Authorization Framework](http://tools.ietf.org/html/rfc6749) specified in [RFC 6749](http://tools.ietf.org/html/rfc6749) to get an authorization grant and uses it access the API.
+
+The customizable options for this scheme are:
+
++ `authorization_endpoint` is the authorization endpoint required for the authorization grant. "/authorize" is the **default**.
++ `access_token_endpoint` is the token endpoint used by client to obtain the access token. "/access_token" is the **default**.
++ `token_header_keyword` represents the string used instead of "Bearer" in "Authorization" header field according to [RFC 6750](http://tools.ietf.org/html/rfc6750#section-2.1). "Bearer" is the **default**.
++ `token_body_keyword` represents the parameter name used instead of "access_token" in the body of an API request according to [RFC 6750](http://tools.ietf.org/html/rfc6750#section-2.2). "access_token" is the **default**.
++ `token_query_keyword` represents the parameter name used instead of "access_token" in the query of an API request according to [RFC 6750](http://tools.ietf.org/html/rfc6750#section-2.3). "access_token" is the **default**.
+
+##### Example
+
+    + oauth (Oauth2 Auth Scheme)
+        + access_token_endpoint: `/token`
+        + token_header_keyword: `token`
+
+#### Bearer Auth Scheme
+This scheme is popularly used when API consumers has access to their own unique access token which can be used as a bearer token as specified in [RFC 6750](https://tools.ietf.org/html/rfc6750#section-2.1).
+
+The customizable options for this scheme are:
+
++ `keyword` represents the string used instead of "Bearer" in the "Authorization" header field according to [RFC 6750](https://tools.ietf.org/html/rfc6750#section-2.1). "Bearer" is the **default**.
+
+##### Example
+
+    + token (Bearer Auth Scheme)
+        + keyword: `token`
 
 ---
 
@@ -768,7 +920,7 @@ One HTTP request-message example – payload.
 <a name="def-response-section"></a>
 ## Response section
 - **Abstract**
-- **Parent sections:** [Action section](#def-action-section)
+- **Parent sections:** [Action section](#def-action-section) | [Authentication section](#def-authentication-section)
 - **Nested sections:** [Refer to payload section](#def-payload-section)
 - **Markdown entity:** list
 - **Inherits from**: [Payload section](#def-payload-section)
@@ -872,6 +1024,7 @@ Where:
             + `B`
             + `C` - This is character C
 ```
+
 ---
 
 <a name="def-attributes-section"></a>

--- a/API Blueprint Specification.md
+++ b/API Blueprint Specification.md
@@ -30,8 +30,6 @@ Version: 1A8
 ### Section Basics
 + [Metadata section](#def-metadata-section)
 + [API name & overview section](#def-api-name-section)
-+ [Authentication section](#def-authentication-section)
-+ [Authentication schemes section](#def-authenticationschemes-section)
 + [Resource group section](#def-resourcegroup-section)
 + [Resource section](#def-resource-section)
 + [Resource model section](#def-model-section)
@@ -47,7 +45,9 @@ Version: 1A8
 ### Going Further
 + [Data Structures section](#def-data-structures)
 + [Relation section](#def-relation-section)
-
++ [Authentication section](#def-authentication-section)
++ [Authentication schemes section](#def-authenticationschemes-section)
++ [Authenticated section](#def-authenticated-section)
 
 ## [III. Appendix](#def-appendix)
 + [URI Templates](#def-uri-templates)
@@ -94,11 +94,11 @@ All of the blueprint sections are optional. However, when present, a section **m
         + [`0-1` **Schema** section](#def-schema-section)
     + [`1+` **Action** sections](#def-action-section)
         + [`0-1` **Relation** section](#def-relation-section)
-        + [`0-1` **Authentication** section](#def-authentication-section)
+        + [`0-1` **Authenticated** section](#def-authenticated-section)
         + [`0-1` **URI Parameters** section](#def-uriparameters-section)
         + [`0-1` **Attributes** section](#def-attributes-section)
         + [`0+` **Request** sections](#def-request-section)
-            + [`0-1` **Authentication** section](#def-authentication-section)
+            + [`0-1` **Authenticated** section](#def-authenticated-section)
             + [`0-1` **Headers** section](#def-headers-section)
             + [`0-1` **Attributes** section](#def-attributes-section)
             + [`0-1` **Body** section](#def-body-section)
@@ -226,6 +226,7 @@ Following reserved keywords are used in section definitions:
 - `Relation`
 - `Authentication`
 - `Authentication Schemes`
+- `Authenticated`
 
 > **NOTE: Avoid using these keywords in other Markdown headers or lists**
 
@@ -490,9 +491,9 @@ Name and description of the API
 
 <a name="def-authentication-section"></a>
 ## Authentication section
-- **Parent sections:** none, [Action section](#def-action-section), [Request section](#def-request-section)
+- **Parent sections:** none
 - **Nested sections:** [`1` Authentication schemes section](#def-authenticationschemes-section), [`1` Response section](#def-response-section)
-- **Markdown entity:** header, list
+- **Markdown entity:** header
 - **Inherits from**: none
 
 #### Definition
@@ -500,23 +501,12 @@ Defined by the `Authentication` keyword in Markdown header entity.
 
     # Authentication
 
-**-- or --**
-
-Defined by the `Authentication` keyword in Markdown list entity followed by optional comma seperated list of scheme names which is prefixed by a colon.
-
-    + Authentication: <list>
-
-> **NOTE:** The second notation is only used when the parent section is either an [Action section](#def-action-section) or a [Request section](#def-request-section).
-
 #### Description
-Based on the parent section, the usage of this section differs as shown below.
-
-#### API Authentication section
-Description of the authentication support for the whole API.
+Description of the authentication settings for the whole API.
 
 This section **should** include one [Authentication schemes section](#def-authenticationschemes-section) and one [Response section](#def-response-section).
 
-The [Authentication schemes section](#def-authenticationschemes-section) defines all the types of authentication schemes supported by the API. Where as, the [Response section](#def-response-section) describes the error response given by an authentication protected endpoint when no authentication is provided with the request.
+The [Authentication schemes section](#def-authenticationschemes-section) defines all the types of authentication schemes supported by the API. The [Response section](#def-response-section) describes the error message returned in the case of failed authentication.
 
 ##### Example
 
@@ -533,67 +523,12 @@ The [Authentication schemes section](#def-authenticationschemes-section) defines
               "type": "error"
             }
 
-#### Request Authentication section
-Description of the request level authentication settings.
-
-If defined inside a [Request section](#def-request-section) of a HTTP transaction example, it implies that the API's response will be the same as the respective response when a valid authentication is sent along with the above mentioned request. This allows another HTTP transaction example to be specified for the cases where an authentication is not needed.
-
-This section **should** not have any nested sections.
-
-If a list of scheme names is provided after the `Authentication` keyword, then only those particular authentication schemes will be allowed for the respective HTTP transaction.
-
-```
-+ Authentication
-```
-
-```
-+ Authentication: basic, token
-```
-
-##### Example
-
-    ## GET /users/bond
-
-    + Response 200 (application/json)
-
-            {
-                "username": "bond"
-            }
-
-    + Request
-        + Authentication
-
-    + Response 200 (application/json)
-
-            {
-                "username": "bond",
-                "email": "james@bo.nd",
-                "bio": "I am 007"
-            }
-
-#### Action Authentication section
-Description of the action level authentication settings.
-
-If defined, all the [Request sections](#def-requestion-section) of the respective [Action section](#def-action-section) inherits the authentication settings unless specified otherwise.
-
-This section **should** not have any nested sections.
-
-##### Example
-
-    ## Retrieve User [GET]
-
-    + Authentication
-
-    + Response 200
-
-            { ... }
-
 ---
 
 <a name="def-authenticationschemes-section"></a>
 ## Authentication schemes section
 - **Parent sections:** [Authentication section](#def-authentication-section)
-- **Nested sections:** See below
+- **Nested sections:** none
 - **Markdown entity:** list
 - **Inherits from**: none
 
@@ -629,17 +564,17 @@ This is the [Basic Authentication Scheme](http://tools.ietf.org/html/rfc2617#sec
 
 The customizable options for this scheme are:
 
-+ `sample_username` represents a sample username value. "sample_user" is the **default**.
-+ `sample_password` represents a sample password value. "sample_pass" is the **default**.
++ `example_username` represents a example username value. "example_user" is the **default**.
++ `example_password` represents a example password value. "example_pass" is the **default**.
 
 ##### Example
 
-    + basic (Basic Auth Scheme)
-        + sample_username: `bond`
-        + sample_password: `Iam007`
+    + basic (Basic Authentication Scheme)
+        + example_username: `john`
+        + example_password: `password`
 
-#### Oauth2 Authentication Scheme
-This scheme uses the [Oauth2 Authorization Framework](http://tools.ietf.org/html/rfc6749) specified in [RFC 6749](http://tools.ietf.org/html/rfc6749) to get an authorization grant and uses it access the API.
+#### OAuth2 Authentication Scheme
+This scheme uses the [OAuth2 Authorization Framework](http://tools.ietf.org/html/rfc6749) specified in [RFC 6749](http://tools.ietf.org/html/rfc6749) to get an authorization grant which is then used to access the API.
 
 The customizable options for this scheme are:
 
@@ -648,26 +583,98 @@ The customizable options for this scheme are:
 + `token_header_keyword` represents the string used instead of "Bearer" in "Authorization" header field according to [RFC 6750](http://tools.ietf.org/html/rfc6750#section-2.1). "Bearer" is the **default**.
 + `token_body_keyword` represents the parameter name used instead of "access_token" in the body of an API request according to [RFC 6750](http://tools.ietf.org/html/rfc6750#section-2.2). "access_token" is the **default**.
 + `token_query_keyword` represents the parameter name used instead of "access_token" in the query of an API request according to [RFC 6750](http://tools.ietf.org/html/rfc6750#section-2.3). "access_token" is the **default**.
-+ `sample_token` represens a sample access token value. "sample_token" is the **default**.
++ `example_token` represens a example access token value. "example_token" is the **default**.
 
 ##### Example
 
-    + oauth (Oauth2 Auth Scheme)
+    + oauth (OAuth2 Authentication Scheme)
         + access_token_endpoint: `/token`
         + token_header_keyword: `token`
 
 #### Bearer Authentication Scheme
-This scheme is popularly used when API consumers has access to their own unique access token which can be used as a bearer token as specified in [RFC 6750](https://tools.ietf.org/html/rfc6750#section-2.1).
+This scheme represents the method of sending a bearer token as specified in [RFC 6750](https://tools.ietf.org/html/rfc6750#section-2.1).
 
 The customizable options for this scheme are:
 
 + `keyword` represents the string used instead of "Bearer" in the "Authorization" header field according to [RFC 6750](https://tools.ietf.org/html/rfc6750#section-2.1). "Bearer" is the **default**.
-+ `sample_token` represents a sample bearer token value. "sample_token" is the **default**.
++ `example_token` represents a example bearer token value. "example_token" is the **default**.
 
 ##### Example
 
-    + token (Bearer Auth Scheme)
+    + token (Bearer Authentication Scheme)
         + keyword: `token`
+
+---
+
+## Authenticated section
+- **Parent sections:** [Action section](#def-action-section), [Request section](#def-request-section)
+- **Nested sections:** none
+- **Markdown entity:** list
+- **Inherits from**: none
+
+#### Definition
+Defined by the `Authenticated` keyword in Markdown list entity followed by optional comma seperated list of scheme names which are prefixed by a colon.
+
+    + Authenticated: <list>
+
+#### Description
+This section does @TODO
+
+#### Request Authentication section
+Description of the request level authentication settings.
+
+If defined inside a [Request section](#def-request-section) of a HTTP transaction example, it implies that the API's response will be the same as the respective response when a valid authentication is sent along with the above mentioned request. This allows another HTTP transaction example to be specified for the cases where an authentication is not needed.
+
+This section **should** not have any nested sections.
+
+If a list of scheme names is provided after the `Authenticated` keyword, then only those particular authentication schemes will be allowed for the respective HTTP transaction.
+
+```
++ Authenticated
+```
+
+```
++ Authenticated: basic, token
+```
+
+##### Example
+
+    ## GET /users/bond
+
+    + Response 200 (application/json)
+
+            {
+              "username": "john"
+            }
+
+    + Request (application/json)
+        + Authenticated
+
+    + Response 200 (application/json)
+
+            {
+              "username": "john",
+              "email": "john@appleseed.com",
+            }
+
+#### Action Authentication section
+Description of the action level authentication settings.
+
+If defined, all the [Request sections](#def-requestion-section) of the respective [Action section](#def-action-section) inherits the authentication settings unless specified otherwise.
+
+This section **should** not have any nested sections.
+
+##### Example
+
+    ## Retrieve User [GET]
+
+    + Authenticated
+
+    + Response 200
+
+            {
+              "username": "john"
+            }
 
 ---
 

--- a/API Blueprint Specification.md
+++ b/API Blueprint Specification.md
@@ -697,7 +697,7 @@ This section **should** include at least one nested [Action section](#def-action
 
     URI parameters defined in the scope of a Resource section apply to _any and all_ nested Action sections except when an [URI template][uritemplate] has been defined for the Action.
 
-- [`0-1` Attributes section][]
+- [`0-1` Attributes section](#def-attributes-section)
 
     Attributes defined in the scope of a Resource section represent Resource attributes. If the resource is defined with a name these attributes **may** be referenced in [Attributes sections][].
 
@@ -972,9 +972,9 @@ This section **must** be composed of nested list items only. This section **must
 
 Where:
 
-+ `<parameter name>` is the parameter name as written in [Resource Section](#ResourceSection)'s URI (e.g. "id").
++ `<parameter name>` is the parameter name as written in [Resource Section](#def-resource-section)'s URI (e.g. "id").
 + `<description>` is any **optional** Markdown-formatted description of the parameter.
-+ `<additional description>` is any additional **optional** Markdown-formatted [description](#SectionDescription) of the parameter.
++ `<additional description>` is any additional **optional** Markdown-formatted [description](#def-description) of the parameter.
 + `<default value>` is an **optional** default value of the parameter – a value that is used when no value is explicitly set (optional parameters only).
 + `<example value>` is an **optional** example value of the parameter (e.g. `1234`).
 + `<type>` is the **optional** parameter type as expected by the API (e.g. "number", "string", "boolean"). "string" is the **default**.
@@ -1187,7 +1187,7 @@ Defined by the `Data Structures` keyword.
 #### Description
 This section holds arbitrary data structures definitions defined in the form of [MSON Named Types][].
 
-Data structures defined in this section **may** be used in any [Attributes section][]. Similarly, any data structures defined in a [Attributes section][] of a named [Resource Section][] **may** be used in a data structure definition.
+Data structures defined in this section **may** be used in any [Attributes section][]. Similarly, any data structures defined in a [Attributes section][] of a named [Resource section][] **may** be used in a data structure definition.
 
 Refer to the [MSON][] specification for full details on how to define an MSON Named type.
 
@@ -1407,10 +1407,8 @@ With `varone := 42`, `vartwo = hello`, `varthree = 1024` the expansion is `/path
 [MSON Named Types]: https://github.com/apiaryio/mson/blob/master/MSON%20Specification.md#22-named-types
 [MSON Type Definition]: https://github.com/apiaryio/mson/blob/master/MSON%20Specification.md#35-type-definition
 
-[`0-1` Attributes section]: #def-attributes-section
 [Attributes section]: #def-attributes-section
 [Attributes sections]: #def-attributes-section
 
-[Resource Section]: #def-resource-section
-
+[Resource section]: #def-resource-section
 [Request section]: #def-request-section

--- a/API Blueprint Specification.md
+++ b/API Blueprint Specification.md
@@ -600,7 +600,7 @@ The customizable options for this scheme are:
         + oauth_resource_endpoint: `/oauth`
         + access_token_endpoint: `/token`
         + token_header_keyword: `token`
-        + scopes: read, write
+        + scopes: read, write, email
 
 #### Bearer Authentication Scheme
 This scheme represents the method of sending a bearer token as specified in [RFC 6750](https://tools.ietf.org/html/rfc6750#section-2.1).
@@ -628,29 +628,75 @@ Defined by the `Authenticated` keyword in Markdown list entity followed by optio
 
     + Authenticated: <list>
 
+> **NOTE:** If name of an authentication scheme dervied from `OAuth2 Authentication Scheme` is used, it can optionally have comma seperated list of oauth scopes inside `[]` immediately following it.
+
 #### Description
-This section does @TODO
+This section describes an authentication setting. Based on the parent section, the authentication setting being described is one of the following:
 
-#### Request Authenticated section
-Description of the request level authentication settings.
+1. Resource authentication setting ([Resource section](#def-resource-section))
+2. Action authentication setting ([Action section](#def-action-section))
+3. Request authentication setting ([Request section](#def-request-section))
 
-If defined inside a [Request section](#def-request-section) of a HTTP transaction example, it implies that the API's response will be the same as the respective response when a valid authentication is sent along with the above mentioned request. This allows another HTTP transaction example to be specified for the cases where an authentication is not needed.
+The authentication setting for a [Request section](#def-request-section) denotes the authentication needed to be sent along with the request to get the [Response section](#def-response-section) of the respective transaction example.
 
-This section **should** not have any nested sections.
-
-If a list of scheme names is provided after the `Authenticated` keyword, then only those particular authentication schemes will be allowed for the respective HTTP transaction.
+If the authentication setting contains only the `Authenticated` keyword, the transaction example allows all the authentication schemes described in the [Authentication schemes section](#def-authenticationschemes-section).
 
 ```
 + Authenticated
 ```
 
+If the authentcation setting contains a list of scheme names after the `Authenticated` keyword, the transaction example only allows the specific authentication schemes denoted by the scheme names.
+
 ```
-+ Authenticated: basic, token
++ Authenticated: oauth, token
 ```
+
+```
++ Authenticated: oauth[read, email], token
+```
+
+#### Resource Authenticated description
+Description of the resource authentication setting.
+
+If defined in a [Resource section](#def-resource-section), all the requests of the transaction examples under this resource will inherit the authentication setting unless specified otherwise.
 
 ##### Example
 
-    ## GET /users/bond
+    # User [/user]
+
+    + Authenticated
+
+    ## Retrieve User [GET]
+
+    + Response 200
+
+            {
+              "username": "john"
+            }
+
+#### Action Authenticated description
+Description of the action authenticated setting.
+
+If defined in an [Action section](#def-action-section), all the requests of the transaction examples under this action will inherit the authentication setting unless specified otherwise.
+
+##### Example
+
+    ## Retrieve User [GET]
+
+    + Authenticated
+
+    + Response 200
+
+            {
+              "username": "john"
+            }
+
+#### Request Authenticated description
+Description of the request authentication setting.
+
+##### Example
+
+    ## Retrieve User [GET]
 
     + Response 200 (application/json)
 
@@ -666,25 +712,6 @@ If a list of scheme names is provided after the `Authenticated` keyword, then on
             {
               "username": "john",
               "email": "john@appleseed.com",
-            }
-
-#### Action Authenticated section
-Description of the action level authentication settings.
-
-If defined, all the [Request sections](#def-requestion-section) of the respective [Action section](#def-action-section) inherits the authentication settings unless specified otherwise.
-
-This section **should** not have any nested sections.
-
-##### Example
-
-    ## Retrieve User [GET]
-
-    + Authenticated
-
-    + Response 200
-
-            {
-              "username": "john"
             }
 
 ---

--- a/API Blueprint Specification.md
+++ b/API Blueprint Specification.md
@@ -85,6 +85,7 @@ All of the blueprint sections are optional. However, when present, a section **m
     + [`1` **Authentication schemes** section](#def-authenticationschemes-section)
     + [`1` **Response** section](#def-response-section)
 + [`0+` **Resource** sections](#def-resource-section)
+    + [`0-1` **Authenticated** section](#def-authenticated-section)
     + [`0-1` **URI Parameters** section](#def-uriparameters-section)
     + [`0-1` **Attributes** section](#def-attributes-section)
     + [`0-1` **Model** section](#def-model-section)
@@ -502,7 +503,7 @@ Defined by the `Authentication` keyword in Markdown header entity.
     # Authentication
 
 #### Description
-Description of the authentication settings for the whole API.
+Authentication settings for the whole API.
 
 This section **should** include one [Authentication schemes section](#def-authenticationschemes-section) and one [Response section](#def-response-section).
 
@@ -538,34 +539,37 @@ Defined by the `Authentication Schemes` keyword.
     + Authentication Schemes
 
 #### Description
-Description of the list of authentication schemes supported by the API.
+List of authentication schemes supported by the API.
+
+API Blueprint supports three **Base Authentication Schemes** (described below) which can be customized to derive authentication schemes supported by the API. Each of the base authentication schemes have a list of customizable options.
+
+Each authentication scheme is defined by an authentication scheme [name (identifier)](#def-identifier), base authentication scheme and the respective customized options.
 
 This section **must** be composed of nested list items only. This section **must not** contain any other elements. Each list item describes a single Authentication scheme.
 
     + <scheme name> (<base scheme type>) - <description>
 
-        + `<key 1>`: <value 1>
-        + `<key 2>`: <value 2>
+        + <customizable option 1>
+        + <customizable option 2>
         ...
-        + `<key N>`: <value N>
+        + <customizable option N>
 
 Where:
 
-+ `<scheme name>` is the scheme name as written in [Authentication section](#def-authentication-section) under an [Action section](#def-action-section).
++ `<scheme name>` is the authentication scheme name by which this scheme is represented in [Authenticated section](#def-authenticated-section).
 + `<description>` is any **optional** Markdown-formatted description of the authentication scheme.
-+ `<base scheme type>` is the authentication scheme type as expected by the API (e.g. "Basic Auth Scheme"). See below for all the available base authentication schemes.
-+ `<key n>` represents a key of an customizable option in the base authentication scheme.
-+ `<value n>` represents the value for the option with the key `<key n>`.
++ `<base scheme type>` is the base authentication scheme type (e.g. "Basic Authentication Scheme"). See below for all the available base authentication schemes.
++ `<customizable option n>` represents a customizable option in the base authentication scheme. It is a [MSON Property Member Declaration][] without the [MSON Type Definition][] where the [MSON Property Name][] represents the name of the option and [MSON Value][] represents the value of the option.
 
-Description of the base authentication schemes inherently defined in API Blueprint are defined below.
+List of the base authentication schemes supported by API Blueprint are described below.
 
 #### Basic Authentication Scheme
 This is the [Basic Authentication Scheme](http://tools.ietf.org/html/rfc2617#section-2) as specified in [RFC 2617](http://tools.ietf.org/html/rfc2617).
 
 The customizable options for this scheme are:
 
-+ `example_username` represents a example username value. "example_user" is the **default**.
-+ `example_password` represents a example password value. "example_pass" is the **default**.
++ `example_username` represents an example username value. Value type is **string**. "example_user" is the **default**.
++ `example_password` represents an example password value. Value type is **string**. "example_pass" is the **default**.
 
 ##### Example
 
@@ -578,26 +582,33 @@ This scheme uses the [OAuth2 Authorization Framework](http://tools.ietf.org/html
 
 The customizable options for this scheme are:
 
-+ `authorization_endpoint` is the authorization endpoint required for the authorization grant. "/authorize" is the **default**.
-+ `access_token_endpoint` is the token endpoint used by client to obtain the access token. "/access_token" is the **default**.
-+ `token_header_keyword` represents the string used instead of "Bearer" in "Authorization" header field according to [RFC 6750](http://tools.ietf.org/html/rfc6750#section-2.1). "Bearer" is the **default**.
-+ `token_body_keyword` represents the parameter name used instead of "access_token" in the body of an API request according to [RFC 6750](http://tools.ietf.org/html/rfc6750#section-2.2). "access_token" is the **default**.
-+ `token_query_keyword` represents the parameter name used instead of "access_token" in the query of an API request according to [RFC 6750](http://tools.ietf.org/html/rfc6750#section-2.3). "access_token" is the **default**.
-+ `example_token` represens a example access token value. "example_token" is the **default**.
++ `oauth_resource_endpoint` is the oauth resource endpoint where the oauth framework resides. Value type is **string**. "/" is the **default**.
++ `scopes` represents the OAuth scopes which indicate a list of permissions. Value type is **array**. By **default** no scopes are specified.
++ `authorization_endpoint` is the authorization endpoint required for the authorization grant. Value type is **string**. "/authorize" is the **default**.
++ `access_token_endpoint` is the token endpoint used by client to obtain the access token. Value type is **string**. "/access_token" is the **default**.
++ `revocation_endpoint` is the revocation endpoint used by client to revoke a token. Value type is **string**. "/revoke" is the **default**.
++ `token_header_keyword` represents the string used instead of "Bearer" in "Authorization" header field according to [RFC 6750](http://tools.ietf.org/html/rfc6750#section-2.1). Value type is **string**. "Bearer" is the **default**.
++ `token_body_keyword` represents the parameter name used instead of "access_token" in the body of an API request according to [RFC 6750](http://tools.ietf.org/html/rfc6750#section-2.2). Value type is **string**. "access_token" is the **default**.
++ `token_query_keyword` represents the parameter name used instead of "access_token" in the query of an API request according to [RFC 6750](http://tools.ietf.org/html/rfc6750#section-2.3). Value type is **string**. "access_token" is the **default**.
++ `example_token` represents an example access token value. Value type is **string**. "example_token" is the **default**.
+
+> **NOTE:** The value for `oauth_resource_endpoint` can include hostnames. `authorization_endpoint` and `access_token_endpoint` allow it too only if `oauth_resource_endpoint` is not specified.
 
 ##### Example
 
     + oauth (OAuth2 Authentication Scheme)
+        + oauth_resource_endpoint: `/oauth`
         + access_token_endpoint: `/token`
         + token_header_keyword: `token`
+        + scopes: read, write
 
 #### Bearer Authentication Scheme
 This scheme represents the method of sending a bearer token as specified in [RFC 6750](https://tools.ietf.org/html/rfc6750#section-2.1).
 
 The customizable options for this scheme are:
 
-+ `keyword` represents the string used instead of "Bearer" in the "Authorization" header field according to [RFC 6750](https://tools.ietf.org/html/rfc6750#section-2.1). "Bearer" is the **default**.
-+ `example_token` represents a example bearer token value. "example_token" is the **default**.
++ `keyword` represents the string used instead of "Bearer" in the "Authorization" header field according to [RFC 6750](https://tools.ietf.org/html/rfc6750#section-2.1). Value type is **string**. "Bearer" is the **default**.
++ `example_token` represents an example bearer token value. Value type is **string**. "example_token" is the **default**.
 
 ##### Example
 
@@ -607,7 +618,7 @@ The customizable options for this scheme are:
 ---
 
 ## Authenticated section
-- **Parent sections:** [Action section](#def-action-section), [Request section](#def-request-section)
+- **Parent sections:** [Resource section](#def-resource-section), [Action section](#def-action-section), [Request section](#def-request-section)
 - **Nested sections:** none
 - **Markdown entity:** list
 - **Inherits from**: none
@@ -620,7 +631,7 @@ Defined by the `Authenticated` keyword in Markdown list entity followed by optio
 #### Description
 This section does @TODO
 
-#### Request Authentication section
+#### Request Authenticated section
 Description of the request level authentication settings.
 
 If defined inside a [Request section](#def-request-section) of a HTTP transaction example, it implies that the API's response will be the same as the respective response when a valid authentication is sent along with the above mentioned request. This allows another HTTP transaction example to be specified for the cases where an authentication is not needed.
@@ -657,7 +668,7 @@ If a list of scheme names is provided after the `Authenticated` keyword, then on
               "email": "john@appleseed.com",
             }
 
-#### Action Authentication section
+#### Action Authenticated section
 Description of the action level authentication settings.
 
 If defined, all the [Request sections](#def-requestion-section) of the respective [Action section](#def-action-section) inherits the authentication settings unless specified otherwise.
@@ -1453,7 +1464,10 @@ With `varone := 42`, `vartwo = hello`, `varthree = 1024` the expansion is `/path
 
 [MSON]: https://github.com/apiaryio/mson
 [MSON Named Types]: https://github.com/apiaryio/mson/blob/master/MSON%20Specification.md#22-named-types
+[MSON Property Member Declaration]: https://github.com/apiaryio/mson/blob/master/MSON%20Specification.md#32-property-member-declaration
 [MSON Type Definition]: https://github.com/apiaryio/mson/blob/master/MSON%20Specification.md#35-type-definition
+[MSON Property Name]: https://github.com/apiaryio/mson/blob/master/MSON%20Specification.md#321-property-name
+[MSON Value]: https://github.com/apiaryio/mson/blob/master/MSON%20Specification.md#341-value
 
 [Attributes section]: #def-attributes-section
 [Attributes sections]: #def-attributes-section

--- a/examples/12. Advanced Action.md
+++ b/examples/12. Advanced Action.md
@@ -6,6 +6,7 @@ A resource action is – in fact – a state transition. This API example demons
 ## API Blueprint
 + [Previous: Resource Model](11.%20Resource%20Model.md)
 + [This: Raw API Blueprint](https://raw.github.com/apiaryio/api-blueprint/master/examples/12.%20Advanced%20Action.md)
++ [Next: Authentication](13.%20Authentication.md)
 
 # Tasks [/tasks/tasks{?status,priority}]
 

--- a/examples/13. Authentication.md
+++ b/examples/13. Authentication.md
@@ -7,11 +7,11 @@ FORMAT: 1A
 + [This: Raw API Blueprint](https://raw.github.com/apiaryio/api-blueprint/master/examples/13.%20Authentication.md)
 
 ## Authentication
-The allowed authentication schemes for the API server are defined below.
+The allowed authentication schemes for the API are defined below.
 
 + Authentication Schemes
-    + basic (Basic Auth Scheme) - Using the username and password directly
-    + oauth (Oauth2 Auth Scheme)
+    + basic (Basic Authentication Scheme) - Using the username and password directly
+    + oauth (OAuth2 Authentication Scheme)
         + authorization_endpoint: `/authorize`
         + access_token_endpoint: `/access_token`
         + token_header_keyword: `token`
@@ -28,14 +28,13 @@ The allowed authentication schemes for the API server are defined below.
 ### Retrieve a User Profile [GET]
 This endpoint needs authentication from the user before retrieving his profile data.
 
-+ Authentication
++ Authenticated
 
 + Response 200 (application/json)
 
         {
-          "username": "bond",
-          "email": "james@bo.nd",
-          "description": "I am James Bond"
+          "username": "john",
+          "email": "john@appleseed.com"
         }
 
 ### Update a User Profile [POST]
@@ -43,15 +42,19 @@ This endpoint needs `basic` scheme authentication from the user before updating 
 
 + Request (application/json)
 
-    + Authentication: basic
+    + Authenticated: basic
 
-    + Attributes
-        + description: "I am Bond, James Bond"
+    + Body
+
+            {
+              "email": "john@apple.com"
+            }
 
 + Response 200 (application/json)
 
-        {
-          "username": "bond",
-          "email": "james@bo.nd",
-          "description": "I am Bond, James Bond"
-        }
+    + Body
+
+          {
+            "username": "john",
+            "email": "john@apple.com"
+          }

--- a/examples/13. Authentication.md
+++ b/examples/13. Authentication.md
@@ -5,6 +5,7 @@ FORMAT: 1A
 ## API Blueprint
 + [Previous: Advanced Action](12.%20Advanced%20Action.md)
 + [This: Raw API Blueprint](https://raw.github.com/apiaryio/api-blueprint/master/examples/13.%20Authentication.md)
++ [Next: Advanced Authentication](14.%20Advanced%20Authentication.md)
 
 ## Authentication
 The allowed authentication schemes for the API are defined below.

--- a/examples/13. Authentication.md
+++ b/examples/13. Authentication.md
@@ -11,11 +11,6 @@ The allowed authentication schemes for the API are defined below.
 
 + Authentication Schemes
     + basic (Basic Authentication Scheme) - Using the username and password directly
-    + oauth (OAuth2 Authentication Scheme)
-        + authorization_endpoint: `/authorize`
-        + access_token_endpoint: `/access_token`
-        + token_header_keyword: `token`
-        + token_query_keyword: `access_token`
 
 + Response 403 (application/json)
 
@@ -23,12 +18,22 @@ The allowed authentication schemes for the API are defined below.
           "error": "Requires Authentication"
         }
 
-## User [/user]
+## User [/user/{id}]
+
++ Parameters
+    + id (string) - Username of the user
 
 ### Retrieve a User Profile [GET]
-This endpoint needs authentication from the user before retrieving his profile data.
+This endpoint sends one response when authentication is present and another response when it is not.
 
-+ Authenticated
++ Response 200 (application/json)
+
+        {
+          "username": "john"
+        }
+
++ Request (application/json)
+    + Authenticated
 
 + Response 200 (application/json)
 
@@ -38,23 +43,19 @@ This endpoint needs authentication from the user before retrieving his profile d
         }
 
 ### Update a User Profile [POST]
-This endpoint needs `basic` scheme authentication from the user before updating his profile data. Even if an authentication of type `oauth` is provided, the API will return an authentication error.
+This endpoint needs authentication from the user before updating his profile data.
+
++ Authenticated
 
 + Request (application/json)
 
-    + Authenticated: basic
-
-    + Body
-
-            {
-              "email": "john@apple.com"
-            }
+        {
+          "email": "john@apple.com"
+        }
 
 + Response 200 (application/json)
 
-    + Body
-
-          {
-            "username": "john",
-            "email": "john@apple.com"
-          }
+        {
+          "username": "john",
+          "email": "john@apple.com"
+        }

--- a/examples/13. Authentication.md
+++ b/examples/13. Authentication.md
@@ -41,9 +41,10 @@ This endpoint needs authentication from the user before retrieving his profile d
 ### Update a User Profile [POST]
 This endpoint needs `basic` scheme authentication from the user before updating his profile data. Even if an authentication of type `oauth` is provided, the API will return an authentication error.
 
-+ Authentication: basic
-
 + Request (application/json)
+
+    + Authentication: basic
+
     + Attributes
         + description: "I am Bond, James Bond"
 

--- a/examples/13. Authentication.md
+++ b/examples/13. Authentication.md
@@ -1,0 +1,56 @@
+FORMAT: 1A
+
+# Authentication API
+
+## API Blueprint
++ [Previous: Advanced Action](12.%20Advanced%20Action.md)
++ [This: Raw API Blueprint](https://raw.github.com/apiaryio/api-blueprint/master/examples/13.%20Authentication.md)
+
+## Authentication
+The allowed authentication schemes for the API server are defined below.
+
++ Authentication Schemes
+    + basic (Basic Auth Scheme) - Using the username and password directly
+    + oauth (Oauth2 Auth Scheme)
+        + authorization_endpoint: `/authorize`
+        + access_token_endpoint: `/access_token`
+        + token_header_keyword: `token`
+        + token_query_keyword: `access_token`
+
++ Response 403 (application/json)
+
+        {
+          "error": "Requires Authentication"
+        }
+
+## User [/user]
+
+### Retrieve a User Profile [GET]
+This endpoint needs authentication from the user before retrieving his profile data.
+
++ Authentication
+
++ Response 200 (application/json)
+
+        {
+          "username": "bond",
+          "email": "james@bo.nd",
+          "description": "I am James Bond"
+        }
+
+### Update a User Profile [POST]
+This endpoint needs `basic` scheme authentication from the user before updating his profile data. Even if an authentication of type `oauth` is provided, the API will return an authentication error.
+
++ Authentication: basic
+
++ Request (application/json)
+    + Attributes
+        + description: "I am Bond, James Bond"
+
++ Response 200 (application/json)
+
+        {
+          "username": "bond",
+          "email": "james@bo.nd",
+          "description": "I am Bond, James Bond"
+        }

--- a/examples/14. Advanced Authentication.md
+++ b/examples/14. Advanced Authentication.md
@@ -1,0 +1,64 @@
+FORMAT: 1A
+
+# Advanced Authentication API
+
+## API Blueprint
++ [Previous: Authentication](13.%20Authentication.md)
++ [This: Raw API Blueprint](https://raw.github.com/apiaryio/api-blueprint/master/examples/14.%20Advanced%20Authentication.md)
+
+## Authentication
+The API requires OAuth2 access token for authentication. Available scopes for OAuth2 are `user:read`, `user:write` and `email`.
+
++ Authentication Schemes
+    + oauth (OAuth2 Authentication Scheme) - Using the oauth2 authentication framework
+        + scopes: `user:read`, `user:write`, email
+
++ Response 403 (application/json)
+
+        {
+          "error": "Requires Authentication"
+        }
+
+## User [/user/{id}]
+
++ Parameters
+    + id (string) - Username of the user
+
+### Retrieve a User Profile [GET]
+This endpoint returns an error if no authentication (access token) is given and returns only the username of an user unless the oauth scope of the access token is `user:write` or `email`.
+
++ Authenticated: oauth[`user:read`]
+
++ Response 200 (application/json)
+
+        {
+          "username": "john"
+        }
+
++ Request (application/json)
+    + Authenticated: oauth[`user:write`, email]
+
++ Response 200 (application/json)
+
+        {
+          "username": "john",
+          "email": "john@appleseed.com"
+        }
+
+### Update a User Profile [POST]
+This endpoint allows the user to update an user profile only if the oauth scope of the access token is `user:write`.
+
++ Authenticated: oauth[`user:write`]
+
++ Request (application/json)
+
+        {
+          "email": "john@apple.com"
+        }
+
++ Response 200 (application/json)
+
+        {
+          "username": "john",
+          "email": "john@apple.com"
+        }

--- a/examples/14. Advanced Authentication.md
+++ b/examples/14. Advanced Authentication.md
@@ -11,7 +11,10 @@ The API requires OAuth2 access token for authentication. Available scopes for OA
 
 + Authentication Schemes
     + oauth (OAuth2 Authentication Scheme) - Using the oauth2 authentication framework
-        + scopes: `user:read`, `user:write`, email
+        + scopes
+          + `user:read` - Grant read access to the user's profile excluding his email
+          + `user:write` - Grant read and write access to the user's profile including his email
+          + email - Grant read access to the user's profile including his email
 
 + Response 403 (application/json)
 


### PR DESCRIPTION
This PR includes syntax proposal for Authentication support (#11) in API Blueprint. The syntax adds an `Authentication` section and an `Authentication Schemes` section to the blueprint using which the writer can define the authentication schemes supported by their API and which endpoints need which kind of authentication.

For now, an user can select authentication schemes from a list of schemes which are inherently supported by the API Blueprint. They are:

* Basic Authentication Scheme
* Oauth 2.0 Authentication Scheme
* Bearer Authentication Scheme

For more information, read the spec and the Authentication example in `examples` folder.