### PR TITLE
Use absolute URL for linking to tutorial from advanced tutorial

### DIFF
--- a/Advanced Tutorial.md
+++ b/Advanced Tutorial.md
@@ -2,7 +2,7 @@
 
 Welcome to the advanced API Blueprint tutorial! This tutorial will take you through advanced topics like JSON Schema, request and response attributes, data structures and relation types.
 
-This tutorial assumes that you have read the [API Blueprint Tutorial](./Tutorial.md).
+This tutorial assumes that you have read the [API Blueprint Tutorial](https://github.com/apiaryio/api-blueprint/blob/master/Tutorial.md).
 
 ## JSON Schema
 


### PR DESCRIPTION
All the other links are absolute URIs to GitHub, this PR aligns this link with the others.