### PR TITLE
Wrap lines, use semantic linebreaks

### DIFF
--- a/Advanced Tutorial.md
+++ b/Advanced Tutorial.md
@@ -12,7 +12,8 @@ The schema can describe the type of each member, which members are required, def
 
 ```apib
 ### Create a New Question [POST]
-You may create your own question using this action. It takes a JSON object containing a question and a collection of answers in the form of choices.
+You may create your own question using this action. It takes a JSON object
+containing a question and a collection of answers in the form of choices.
 
 + Request (application/json)
 
@@ -56,7 +57,8 @@ Creating a new question in the polls API can be modeled using MSON:
 
 ```apib
 ### Create a New Question [POST]
-You may create your own question using this action. It takes a JSON object containing a question and a collection of answers in the form of choices.
+You may create your own question using this action. It takes a JSON object
+containing a question and a collection of answers in the form of choices.
 
 + Request (application/json)
 

--- a/Tutorial.md
+++ b/Tutorial.md
@@ -102,7 +102,8 @@ The polls resource has a second action which allows you to create a new question
 ```apib
 ### Create a New Question [POST]
 
-You may create your own question using this action. It takes a JSON object containing a question and a collection of answers in the form of choices.
+You may create your own question using this action. It takes a JSON object
+containing a question and a collection of answers in the form of choices.
 
 + question (string) - The question
 + choices (array[string]) - A collection of choices.


### PR DESCRIPTION
I noticed that the `### Create a New Question [POST]` example
rendered in a box with horisontal scrollbar, with most of the
description scrolling off to the right.

When going to fix this, I noticed that descriptive text wasn't wrapped.
Wrap lines, it's more suited to a plaintext format like markdown.

Semantic linebreaks:
  http://rhodesmill.org/brandon/2012/one-sentence-per-line/