### PR TITLE
Wrap long lines in descriptions

### DIFF
--- a/API Blueprint Specification.md
+++ b/API Blueprint Specification.md
@@ -59,21 +59,31 @@ Version: 1A9
 
 <a name="def-introduction"></a>
 ## Introduction
-This documents is a full specification of the API Blueprint format. For a less formal introduction to API Blueprint visit the [API Blueprint Tutorial](Tutorial.md) or check some of the [examples][].
+This documents is a full specification of the API Blueprint format. For a less
+formal introduction to API Blueprint visit the 
+[API Blueprint Tutorial](Tutorial.md) or check some of the [examples][].
 
 <a name="def-api-blueprint"></a>
 ## API Blueprint
-API Blueprint is a documentation-oriented web API description language. The API Blueprint is essentially a set of semantic assumptions laid on top of the Markdown syntax used to describe a web API.
+API Blueprint is a documentation-oriented web API description language. The
+API Blueprint is essentially a set of semantic assumptions laid on top of the
+Markdown syntax used to describe a web API.
 
-In addition to the regular [Markdown syntax][] API Blueprint conforms to the [GitHub Flavored Markdown syntax][].
+In addition to the regular [Markdown syntax][], API Blueprint conforms to the
+[GitHub Flavored Markdown syntax][].
 
 <a name="def-api-blueprint-document"></a>
 ## API Blueprint document
-An API Blueprint document – a blueprint is a plain text Markdown document describing a Web API or its part. The document is structured into logical **sections**. Each section has its distinctive meaning, content and position in the document.
+An API Blueprint document – a blueprint – is a plain text Markdown document
+describing a Web API in whole or in part. The document is structured into
+logical **sections**. Each section has its distinctive meaning, content and
+position in the document.
 
-General section definition and structure is discussed in detail later in the [Blueprint section](#def-blueprint-section) chapter.
+General section definition and structure is discussed in detail later in the
+[Blueprint section](#def-blueprint-section) chapter.
 
-All of the blueprint sections are optional. However, when present, a section **must** follow the API Blueprint **document structure**.
+All of the blueprint sections are optional. However, when present, a section
+**must** follow the API Blueprint **document structure**.
 
 ### Blueprint document structure
 
@@ -105,20 +115,28 @@ All of the blueprint sections are optional. However, when present, a section **m
     + [`0+` **Resource** sections](#def-resource-section) (see above)
 + [`0+` **Data Structures** section](#def-data-structures)
 
-> **NOTE:** The number prior to a section name denotes the allowed number of the section occurrences.
+> **NOTE:** The number prior to a section name denotes the allowed number of
+> the section occurrences.
 
-> **NOTE:** Refer to [Sections Reference](#def-sections-reference) for  description of a specific section type.
+> **NOTE:** Refer to [Sections Reference](#def-sections-reference) for
+> description of a specific section type.
 
 <a name="def-blueprint-section"></a>
 ## Blueprint section
-Section represents a logical unit of API Blueprint. For example an API overview, a group of resources or a resource definition.
+A _Section_ represents a logical unit of an API Blueprint. For example: an API
+overview, a group of resources or a resource definition.
 
 In general a section is **defined** using a **keyword** in a Markdown entity.
-Depending on the type of section the keyword is written either as a Markdown header entity or in a list item entity.
+Depending on the type of section the keyword is written either as a Markdown
+header entity or in a list item entity.
 
-A section definition **may** also contain additional variable components such as its **identifier** and additional modifiers.
+A section definition **may** also contain additional variable components such
+as its **identifier** and additional modifiers.
 
-> **NOTE**: There are two special sections that are recognized by their position in the document instead of a keyword: The [Metadata section]() and the [API Name & Overview section](). Refer to the respective section entry for details on its definition.
+> **NOTE**: There are two special sections that are recognized by their
+> position in the document instead of a keyword: The [Metadata section]() and
+> the [API Name & Overview section](). Refer to the respective section entry
+> for details on its definition.
 
 #### Example: Header-defined sections
 
@@ -154,7 +172,9 @@ A section definition **may** also contain additional variable components such as
 
      ...
 
-> **NOTE:**  While this specification uses pluses (`+`) as list markers you can use any Markdown [list syntax][] using asterisks (`*`), pluses (`+`) and hyphens (`-`) interchangeably:
+> **NOTE:**  While this specification uses pluses (`+`) as list markers you can
+> use any Markdown [list syntax][] using asterisks (`*`), pluses (`+`) and
+> hyphens (`-`) interchangeably:
 >
 >     * <keyword>
 >
@@ -166,13 +186,19 @@ A section definition **may** also contain additional variable components such as
 
 <a name="def-section-types"></a>
 ### Section types
-There are several types of API Blueprint sections. You can find the complete listing of the section types in the [Section Reference](#def-sections-reference).
+There are several types of API Blueprint sections. You can find the complete
+listing of the section types in the 
+[Section Reference](#def-sections-reference).
 
-**The Blueprint section chapter discusses the section syntax in general. A specific section type may conform only to some parts of this general syntax.** Always refer for respective section reference for details on its syntax.
+**The Blueprint section chapter discusses the section syntax in general.**
+**A specific section type may conform only to some parts of this general syntax.**
+Always refer for respective section reference for details on its syntax.
 
 <a name="def-section-structure"></a>
 ### Section structure
-A general structure of an API Blueprint section defined by a **keyword** includes an **identifier** (name), section **description** and **nested sections** or a specifically formatted content.
+A general structure of an API Blueprint section defined by a **keyword**
+includes an **identifier** (name), section **description** and **nested
+sections** or a specifically formatted content.
 
 #### Example: Header-defined section structure
 
@@ -219,11 +245,14 @@ Following reserved keywords are used in section definitions:
 
 > **NOTE: Avoid using these keywords in other Markdown headers or lists**
 
-> **NOTE:** With the exception of HTTP methods keywords the section keywords are case insensitive.
+> **NOTE:** With the exception of HTTP methods keywords the section keywords
+> are case insensitive.
 
 <a name="def-identifier"></a>
 ### Identifier
-A section definition **may** or **must** include an identifier of the section. An **identifier is any non-empty combination of any character except `[`, `]`, `(`, `)` and newline characters**.
+A section definition **may** or **must** include an identifier of the section.
+An **identifier is any non-empty combination of any character except `[`, `]`,
+`(`, `)` and newline characters**.
 
 An identifier **must not** contain any of the [keywords](#def-keywords).
 
@@ -240,19 +269,27 @@ my-awesome-message_2
 
 <a name="def-description"></a>
 ### Description
-A section description is any arbitrary Markdown-formatted content following the section definition.
+A section description is any arbitrary Markdown-formatted content following the
+section definition.
 
-It is possible to use any Markdown header or list item in a section description as long as it does not clash with any of the [reserved keywords](#def-keywords).
+It is possible to use any Markdown header or list item in a section description
+as long as it does not clash with any of the 
+[reserved keywords](#def-keywords).
 
-> **NOTE:** It is considered good practice to keep the header level nested under the actual section.
+> **NOTE:** It is considered good practice to keep the header level nested
+> under the actual section.
 
 <a name="def-nested-sections"></a>
 ### Nested sections
 A section **may** contain another nested section(s).
 
-Depending on the nested section type, to nest a section simply increase its header level or its list item indentation. Anything between the section start and the start of following section at the same level is considered to be part of the section.
+Depending on the nested section type, to nest a section simply increase its
+header level or its list item indentation. Anything between the section start
+and the start of following section at the same level is considered to be part
+of the section.
 
-What sections can be nested and where depends upon the section in case, as described in the relevant section's entry.
+What sections can be nested and where depends upon the section in case, as
+described in the relevant section's entry.
 
 #### Example: Nested header-defined section
 
@@ -274,15 +311,18 @@ What sections can be nested and where depends upon the section in case, as descr
 
          ...
 
-> **NOTE:** While not necessary it is a good habit to increase the level of a nested section markdown-header.
+> **NOTE:** While not necessary it is a good habit to increase the level of a
+> nested section markdown-header.
 
-> **NOTE:** A markdown-list section is always considered to be nested under the preceding markdown-header section.
+> **NOTE:** A markdown-list section is always considered to be nested under the
+> preceding markdown-header section.
 
 ---
 
 <a name="def-sections-reference"></a>
 # II. Sections Reference
-> **NOTE:** Sections marked as "Abstract" serve as a base for other sections and as such they **cannot** be used directly.
+> **NOTE:** Sections marked as "Abstract" serve as a base for other sections
+> and as such they **cannot** be used directly.
 
 
 # Abstract
@@ -296,7 +336,8 @@ What sections can be nested and where depends upon the section in case, as descr
 - **Inherits from**: none
 
 #### Definition
-Defined by a [keyword](#def-keywords) followed by an optional section name - [identifier](#def-identifier) in a Markdown header or list entity.
+Defined by a [keyword](#def-keywords) followed by an optional section name -
+[identifier](#def-identifier) in a Markdown header or list entity.
 
 ```
 # <keyword> <identifier>
@@ -307,7 +348,10 @@ Defined by a [keyword](#def-keywords) followed by an optional section name - [id
 ```
 
 #### Description
-Named section is the base section for most of the API Blueprint sections. It conforms to the [general section](#def-section-structure) and as such it composes of a section name (identifier), description and nested sections or specific formatted content (see descendants descriptions).
+Named section is the base section for most of the API Blueprint sections. It
+conforms to the [general section](#def-section-structure) and as such it is
+composed of a section name (identifier), description and nested sections or
+specific formatted content (see descendants descriptions).
 
 #### Example
 
@@ -336,7 +380,9 @@ Defined by a [keyword](#def-keywords) in Markdown list entity.
     + <keyword>
 
 #### Description
-Asset section is the base section for atomic data in API Blueprint. The content this section is expected to be a [pre-formatted code block](http://daringfireball.net/projects/markdown/syntax#precode).
+The asset section is the base section for atomic data in API Blueprint. The content
+of this section is expected to be a 
+[pre-formatted code block](http://daringfireball.net/projects/markdown/syntax#precode).
 
 #### Example
 
@@ -367,18 +413,26 @@ Asset section is the base section for atomic data in API Blueprint. The content 
 - **Inherits from**: [Named section](#def-named-section)
 
 #### Definition
-Defined by a [keyword](#def-keywords) in Markdown list entity. The keyword **may** be followed by identifier. The definition **may** include payload's media-type enclosed in braces.
+Defined by a [keyword](#def-keywords) in Markdown list entity. The keyword **may** be followed by identifier.
+The definition **may** include payload's media-type enclosed in braces.
 
     + <keyword> <identifier> (<media type>)
 
 > **NOTE:** Refer to descendant for the particular section type definition.
 
 #### Description
-Payload sections represent the information transferred as a payload of an HTTP request or response messages. A Payload consists of optional meta information in the form of HTTP headers and optional content in the form HTTP body.
+Payload sections represent the information transferred as a payload of an HTTP
+request or response messages. A Payload consists of optional meta information
+in the form of HTTP headers and optional content in the form HTTP body.
 
-Furthermore, in API Blueprint context, a payload include its description, description of its message-body attributes and a message-body validation schema.
+Furthermore, in API Blueprint context, a payload includes its description, a
+description of its message-body attributes and a message-body validation
+schema.
 
-A payload **may** have its media type associated. A payload's media type represents the metadata received or sent in the form of a HTTP `Content-Type` header. When specified a payload **should** include nested [Body section](#def-body-section).
+A payload **may** have its media type associated. A payload's media type
+represents the metadata received or sent in the form of a HTTP `Content-Type`
+header. When specified a payload **should** include nested 
+[Body section](#def-body-section).
 
 This section **should** include at least one of the following nested sections:
 
@@ -387,10 +441,14 @@ This section **should** include at least one of the following nested sections:
 - [`0-1` Body section](#def-body-section)
 - [`0-1` Schema section](#def-schema-section)
 
-If there is no nested section the content of the payload section is considered as content of the [Body section](#def-body-section).
+If there is no nested section the content of the payload section is considered
+as content of the [Body section](#def-body-section).
 
 #### Relation of Body, Schema and Attributes sections
-Each of body, schema and attributes sections describe a message payload's body. These descriptions **should** be consistent, not violating each other. When multiple body descriptions are provided they **should** be prioritized as follows:
+Each of body, schema and attributes sections describe a message payload's body.
+These descriptions **should** be consistent, not violating each other. When
+multiple body descriptions are provided they **should** be prioritized as
+follows:
 
 1. For resolving message-body schema
     1. Schema section
@@ -403,7 +461,9 @@ Each of body, schema and attributes sections describe a message payload's body. 
     3. Schema section
 
 #### Referencing
-Instead of providing a payload section content a [model payload section](#def-model-section) can be referenced using the Markdown implicit [reference syntax][]:
+Instead of providing a payload section content, a 
+[model payload section](#def-model-section) can be referenced using the
+Markdown implicit [reference syntax][]:
 
     [<identifier>][]
 
@@ -445,11 +505,13 @@ Instead of providing a payload section content a [model payload section](#def-mo
 - **Inherits from**: none
 
 #### Definition
-Key value pairs. Key separated from its value by colon (`:`). One pair per line.
-Starts at the beginning of the document and ends with the first Markdown element that is not recognized as a key value pair.
+Key-value pairs. Each key is separated from its value by a colon (`:`). One
+pair per line. Starts at the beginning of the document and ends with the first
+Markdown element that is not recognized as a key-value pair.
 
 #### Description
-Metadata keys and its values are tool-specific. Refer to relevant tool documentation for the list of supported keys.
+Metadata keys and their values are tool-specific. Refer to relevant tool
+documentation for the list of supported keys.
 
 #### Example
 
@@ -466,7 +528,8 @@ Metadata keys and its values are tool-specific. Refer to relevant tool documenta
 - **Inherits from**: [Named section](#def-named-section)
 
 #### Definition
-Defined by the **first** Markdown header in the blueprint document unless it represents another section definition.
+Defined by the **first** Markdown header in the blueprint document, unless it
+represents another section definition.
 
 #### Description
 Name and description of the API
@@ -474,7 +537,8 @@ Name and description of the API
 #### Example
 
     # Basic ACME Blog API
-    Welcome to the **ACME Blog** API. This API provides access to the **ACME Blog** service.
+    Welcome to the **ACME Blog** API. This API provides access to the **ACME
+    Blog** service.
 
 ---
 
@@ -491,7 +555,8 @@ Defined by the `Group` keyword followed by group [name (identifier)](#def-identi
     # Group <identifier>
 
 #### Description
-This sections represents a group of resources (Resource Sections). **May** include one or more nested [Resource Sections](#def-resource-section).
+This section represents a group of resources (Resource Sections). **May**
+include one or more nested [Resource Sections](#def-resource-section).
 
 #### Example
 
@@ -526,7 +591,8 @@ Defined by an [URI template][uritemplate]:
 
 **-- or --**
 
-Defined by a resource [name (identifier)](#def-identifier) followed by an [URI template][uritemplate] enclosed in square brackets `[]`.
+Defined by a resource [name (identifier)](#def-identifier) followed by an 
+[URI template][uritemplate] enclosed in square brackets `[]`.
 
     # <identifier> [<URI template>]
 
@@ -538,30 +604,45 @@ Defined by an [HTTP request method][httpmethods] followed by [URI template][urit
 
 **-- or --**
 
-Defined by a resource [name (identifier)](#def-identifier) followed by an [HTTP request method][httpmethods] and an [URI template][uritemplate] enclosed in square brackets `[]`:
+Defined by a resource [name (identifier)](#def-identifier) followed by an 
+[HTTP request method][httpmethods] and an [URI template][uritemplate] enclosed
+in square brackets `[]`:
 
     # <identifier> [<HTTP request method> <URI template>]
 
-> **NOTE:** In the latter two cases the rest of this section represents the [Action section](#def-action-section) including its description and nested sections and **follows the rules of Action section instead**.
+> **NOTE:** In the latter two cases the rest of this section represents the
+> [Action section](#def-action-section) including its description and nested
+> sections and **follows the rules of the Action section instead**.
 
 #### Description
-An API [resource](http://www.w3.org/TR/di-gloss/#def-resource) as specified by its *URI* or a set of resources (a resource template) matching its *URI template*.
+An API [resource](http://www.w3.org/TR/di-gloss/#def-resource) as specified by
+its *URI* or a set of resources (a resource template) matching its *URI
+template*.
 
-This section **should** include at least one nested [Action section](#def-action-section) and **may** include following nested sections:
+This section **should** include at least one nested 
+[Action section](#def-action-section) and **may** include following nested
+sections:
 
 - [`0-1` URI parameters section](#def-uriparameters-section)
 
-    URI parameters defined in the scope of a Resource section apply to _any and all_ nested Action sections except when an [URI template][uritemplate] has been defined for the Action.
+    URI parameters defined in the scope of a Resource section apply to 
+    _any and all_ nested Action sections except when an [URI template][uritemplate] has
+    been defined for the Action.
 
 - [`0-1` Attributes section][]
 
-    Attributes defined in the scope of a Resource section represent Resource attributes. If the resource is defined with a name these attributes **may** be referenced in [Attributes sections][].
+    Attributes defined in the scope of a Resource section represent Resource
+    attributes. If the resource is defined with a name these attributes **may**
+    be referenced in [Attributes sections][].
 
 - [`0-1` Model section](#def-model-section)
 
 - Additional [Action sections](#def-action-section)
 
-> **NOTE:** A blueprint document may contain multiple sections for the same resource (or resource set), as long as their HTTP methods differ. However it is considered good practice to group multiple HTTP methods under one resource (resource set).
+> **NOTE:** A blueprint document may contain multiple sections for the same
+> resource (or resource set), as long as their HTTP methods differ. However it
+> is considered good practice to group multiple HTTP methods under one resource
+> (resource set).
 
 #### Example
 
@@ -593,10 +674,16 @@ Defined by the `Model` keyword followed by an optional media type:
     + Model (<media type>)
 
 #### Description
-A [resource manifestation](http://www.w3.org/TR/di-gloss/#def-resource-manifestation) - one exemplar representation of the resource in the form of a [payload](#def-payload-section).
+A [resource manifestation](http://www.w3.org/TR/di-gloss/#def-resource-manifestation) - one
+exemplary representation of the resource in the form of a
+[payload](#def-payload-section).
 
 #### Referencing
-The payload defined in this section **may** be referenced in any response or request section in the document using parent section's identifier. You can refer to this payload in any of the following [Request](#def-request-section) or [Response](#def-response-section) payload sections using the Markdown implicit [reference syntax][].
+The payload defined in this section **may** be referenced in any response or
+request section in the document using parent section's identifier. You can
+refer to this payload in any of the following [Request](#def-request-section)
+or [Response](#def-response-section) payload sections using the Markdown
+implicit [reference syntax][].
 
 #### Example
 
@@ -636,7 +723,12 @@ Specifies a validation schema for the HTTP message-body of parent payload sectio
 <a name="def-action-section"></a>
 ## Action section
 - **Parent sections:** [Resource section](#def-resource-section)
-- **Nested sections:** [`0-1` Relation section](#def-relation-section), [`0-1` URI parameters section](#def-uriparameters-section), [`0-1` Attributes section](#def-attributes-section), [`0+` Request section](#def-request-section), [`1+` Response section](#def-response-section)
+- **Nested sections:**
+    [`0-1` Relation section](#def-relation-section),
+    [`0-1` URI parameters section](#def-uriparameters-section),
+    [`0-1` Attributes section](#def-attributes-section),
+    [`0+` Request section](#def-request-section),
+    [`1+` Response section](#def-response-section)
 - **Markdown entity:** header
 - **Inherits from**: [Named section](#def-named-section)
 
@@ -647,28 +739,45 @@ Defined by an [HTTP request method][httpmethods]:
 
 **-- or --**
 
-Defined by an action [name (identifier)](#def-identifier) followed by an [HTTP request method][httpmethods] enclosed in square brackets `[]`.
+Defined by an action [name (identifier)](#def-identifier) followed by an 
+[HTTP request method][httpmethods] enclosed in square brackets `[]`.
 
     ## <identifier> [<HTTP request method>]
 
 **-- or --**
 
-Defined by an action [name (identifier)](#def-identifier) followed by an [HTTP request method][httpmethods] and [URI template][uritemplate] enclosed in square brackets `[]`.
+Defined by an action [name (identifier)](#def-identifier) followed by an 
+[HTTP request method][httpmethods] and 
+[URI template][uritemplate] enclosed in square brackets `[]`.
 
     ## <identifier> [<HTTP request method> <URI template>]
 
 #### Description
-Definition of at least one complete HTTP transaction as performed with the parent resource section. An action section **may** consists of multiple HTTP transaction examples for the given HTTP request method.
+Definition of at least one complete HTTP transaction as performed with the
+parent resource section. An action section **may** consist of multiple HTTP
+transaction examples for the given HTTP request method.
 
-This section **may** include one nested [URI parameters section](#def-uriparameters-section) describing any URI parameters _specific_ to the action – URI parameters discussed in the scope of an Action section apply to the respective Action section ONLY.
+This section **may** include one nested 
+[URI parameters section](#def-uriparameters-section) describing any URI
+parameters _specific_ to the action – URI parameters discussed in the scope of
+an Action section apply to the respective Action section ONLY.
 
-This section **may** include one nested [Attributes section][] defining the input (request) attributes of the section. If present, these attributes **should** be inherited in every Action's [Request section][] unless specified otherwise.
+This section **may** include one nested [Attributes section][] defining the
+input (request) attributes of the section. If present, these attributes
+**should** be inherited in every Action's [Request section][] unless specified
+otherwise.
 
-Action section **should** include at least one nested [Response section](#def-response-section) and **may** include additional nested [Request](#def-request-section) and [Response](#def-response-section) sections.
+Action section **should** include at least one nested 
+[Response section](#def-response-section) and **may** include additional nested 
+[Request](#def-request-section) and [Response](#def-response-section) sections.
 
-Nested Request and Response sections **may** be ordered into groups where each groups represent one transaction example. First transaction example group starts with the first nested Request or Response section. Subsequent groups start with the first nested Request section following a Response section.
+Nested Request and Response sections **may** be ordered into groups where each
+group represents one transaction example. The first transaction example group
+starts with the first nested Request or Response section. Subsequent groups
+start with the first nested Request section following a Response section.
 
-Multiple Request and Response nested sections within one transaction example **should** have different identifiers.
+Multiple Request and Response nested sections within one transaction example
+**should** have different identifiers.
 
 #### Example
 
@@ -747,7 +856,8 @@ Retrieves the list of **ACME Blog** posts.
         ...
 ```
 
-> **NOTE:** The "Multiple Transaction Examples" example demonstrates three transaction examples for one given action:
+> **NOTE:** The "Multiple Transaction Examples" example demonstrates three
+> transaction examples for one given action:
 >
 > 1. 1st example: request `A`, response `200`
 > 2. 2nd example: request `B`, responses `200` and `500`
@@ -788,7 +898,8 @@ One HTTP request-message example – payload.
 - **Inherits from**: [Payload section](#def-payload-section)
 
 #### Definition
-Defined by the `Response` keyword. The response section definition **should** include an [HTTP status code][] as its identifier.
+Defined by the `Response` keyword. The response section definition **should**
+include an [HTTP status code][] as its identifier.
 
     + Response <HTTP status code> (<Media Type>)
 
@@ -818,9 +929,13 @@ Defined by the `Parameters` keyword written in a Markdown list item:
     + Parameters
 
 #### Description
-Discussion of URI parameters in the _scope of the parent section_.
+Discussion of URI parameters _in the scope of the parent section_.
 
-This section **must** be composed of nested list items only. This section **must not** contain any other elements. Each list item describes a single URI parameter. The nested list items subsections inherit from the [Named section](#def-named-section) and are subject to additional formatting as follows:
+This section **must** be composed of nested list items only. This section
+**must not** contain any other elements. Each list item describes a single URI
+parameter. The nested list items subsections inherit from the 
+[Named section](#def-named-section) and are subject to additional formatting as
+follows:
 
     + <parameter name>: `<example value>` (<type> | enum[<type>], required | optional) - <description>
 
@@ -836,18 +951,29 @@ This section **must** be composed of nested list items only. This section **must
 
 Where:
 
-+ `<parameter name>` is the parameter name as written in [Resource Section](#ResourceSection)'s URI (e.g. "id").
-+ `<description>` is any **optional** Markdown-formatted description of the parameter.
-+ `<additional description>` is any additional **optional** Markdown-formatted [description](#SectionDescription) of the parameter.
-+ `<default value>` is an **optional** default value of the parameter – a value that is used when no value is explicitly set (optional parameters only).
++ `<parameter name>` is the parameter name as written in 
+  [Resource Section](#ResourceSection)'s URI (e.g. "id").
++ `<description>` is any **optional** Markdown-formatted description of the
+  parameter.
++ `<additional description>` is any additional **optional** Markdown-formatted
+  [description](#SectionDescription) of the parameter.
++ `<default value>` is an **optional** default value of the parameter – a value
+  that is used when no value is explicitly set (optional parameters only).
 + `<example value>` is an **optional** example value of the parameter (e.g. `1234`).
-+ `<type>` is the **optional** parameter type as expected by the API (e.g. "number", "string", "boolean"). "string" is the **default**.
-+ `Members` is the **optional** enumeration of possible values. `<type>` should be surrounded by `enum[]` if this is present. For example, if enumeration values are present for a parameter whose type is `number`, then `enum[number]` should be used instead of `number` to.
++ `<type>` is the **optional** parameter type as expected by the API (e.g.
+  "number", "string", "boolean"). "string" is the **default**.
++ `Members` is the **optional** enumeration of possible values.
+  `<type>` should be surrounded by `enum[]` if this is present.
+  For example, if enumeration values are present for a parameter whose type is
+  `number`, then `enum[number]` should be used instead of `number` to.
 + `<enumeration value n>` represents an element of enumeration type.
-+ `required` is the **optional** specifier of a required parameter (this is the **default**)
++ `required` is the **optional** specifier of a required parameter 
+  (this is the **default**)
 + `optional` is the **optional** specifier of an optional parameter.
 
-> **NOTE:** This section **should only** contain parameters that are specified in the parent's resource URI template, and does not have to list every URI parameter.
+> **NOTE:** This section **should only** contain parameters that are specified
+> in the parent's resource URI template, and does not have to list every URI
+> parameter.
 
 #### Example
 
@@ -897,11 +1023,14 @@ Where:
 - **Inherits from**: none
 
 #### Definition
-Defined by the `Attributes` keyword followed by an optional [MSON Type Definition][] enclosed in parentheses.
+Defined by the `Attributes` keyword followed by an optional 
+[MSON Type Definition][] enclosed in parentheses.
 
     + Attributes <Type Definition>
 
-`<Type Definition>` is the type definition of the data structure being described. If the `<Type Definition>` is not specified, an `object` base type is assumed. See [MSON Type Definition][] for details.
+`<Type Definition>` is the type definition of the data structure being
+described. If the `<Type Definition>` is not specified, an `object` base type
+is assumed. See [MSON Type Definition][] for details.
 
 ##### Example
 
@@ -910,18 +1039,26 @@ Defined by the `Attributes` keyword followed by an optional [MSON Type Definitio
 ```
 
 #### Description
-This section describes a data structure using the **[Markdown Syntax for Object Notation][MSON] (MSON)**. Based on the parent section, the data structure being described is one of the following:
+This section describes a data structure using the 
+**[Markdown Syntax for Object Notation][MSON] (MSON)**.
+Based on the parent section, the data structure being described is one of the
+following:
 
 1. Resource data structure attributes ([Resource section](#def-resource-section))
 2. Action request attributes ([Action section](#def-action-section))
 3. Payload message-body attributes ([Payload section](#def-payload-section))
 
-Data structures defined in this section **may** refer to any arbitrary data structures defined in the [Data Structures section](#def-data-structures) as well as to any data structures defined by a named resource attributes description (see below).
+Data structures defined in this section **may** refer to any arbitrary data
+structures defined in the [Data Structures section](#def-data-structures) as
+well as to any data structures defined by a named resource attributes
+description (see below).
 
 #### Resource Attributes description
 Description of the resource data structure.
 
-If defined in a named [Resource section](#def-resource-section), this data structure **may** be referenced by other data structures using the resource name.
+If defined in a named [Resource section](#def-resource-section), this data
+structure **may** be referenced by other data structures using the resource
+name.
 
 ##### Example
 
@@ -943,7 +1080,9 @@ Resource representing **ACME Blog** posts.
 #### Action Attributes description
 Description of the default request message-body data structure.
 
-If defined, all the [Request sections](#def-request-section) of the respective [Action section](#def-action-section) inherits these attributes unless specified otherwise.
+If defined, all the [Request sections](#def-request-section) of the respective
+[Action section](#def-action-section) inherits these attributes unless
+specified otherwise.
 
 ##### Example
 
@@ -964,11 +1103,17 @@ If defined, all the [Request sections](#def-request-section) of the respective [
 #### Payload Attributes description
 Description of payload (request, response, model) message-body attributes.
 
-Not every attribute has to be described. However, when an attribute is described, it **should** appear in the respective [Body section](#def-body-section) example, if a Body section is provided.
+Not every attribute has to be described. However, when an attribute is
+described, it **should** appear in the respective 
+[Body section](#def-body-section) example, if a Body section is provided.
 
-If defined, the [Body section](#def-body-section) **may** be omitted and the example representation **should** be generated from the attributes description.
+If defined, the [Body section](#def-body-section) **may** be omitted and the
+example representation **should** be generated from the attributes description.
 
-The description of message-body attributes **may** be used to describe message-body validation if no [Schema section](#def-schema-section) is provided. When a Schema section is provided, the attributes description **should** conform to the schema.
+The description of message-body attributes **may** be used to describe
+message-body validation if no [Schema section](#def-schema-section) is
+provided. When a Schema section is provided, the attributes description
+**should** conform to the schema.
 
 ##### Example
 
@@ -1000,7 +1145,9 @@ Defined by the `Headers` keyword in Markdown list entity.
     + Headers
 
 #### Description
-Specifies the HTTP message-headers of the parent payload section. The content this section is expected to be a [pre-formatted code block](http://daringfireball.net/projects/markdown/syntax#precode) with the following syntax:
+Specifies the HTTP message-headers of the parent payload section. The content
+this section is expected to be a [pre-formatted code block](http://daringfireball.net/projects/markdown/syntax#precode)
+with the following syntax:
 
     <HTTP header name>: <value>
 
@@ -1059,9 +1206,12 @@ Defined by the `Data Structures` keyword.
     # Data Structures
 
 #### Description
-This section holds arbitrary data structures definitions defined in the form of [MSON Named Types][].
+This section holds arbitrary data structures definitions defined in the form of
+[MSON Named Types][].
 
-Data structures defined in this section **may** be used in any [Attributes section][]. Similarly, any data structures defined in a [Attributes section][] of a named [Resource Section][] **may** be used in a data structure definition.
+Data structures defined in this section **may** be used in any [Attributes section][].
+Similarly, any data structures defined in a [Attributes section][] of a named
+[Resource Section][] **may** be used in a data structure definition.
 
 Refer to the [MSON][] specification for full details on how to define an MSON Named type.
 
@@ -1120,12 +1270,14 @@ Refer to the [MSON][] specification for full details on how to define an MSON Na
 - **Inherits from**: none
 
 #### Definition
-Defined by the `Relation` keyword written in a Markdown list item followed by a colon (`:`) and a link relation identifier.
+Defined by the `Relation` keyword written in a Markdown list item followed by a
+colon (`:`) and a link relation identifier.
 
     + Relation: <link relation identifier>
 
 #### Description
-This section specifies a [link relation type](https://tools.ietf.org/html/rfc5988#section-4) for the given action as specified by [RFC 5988](https://tools.ietf.org/html/rfc5988).
+This section specifies a [link relation type](https://tools.ietf.org/html/rfc5988#section-4)
+for the given action as specified by [RFC 5988](https://tools.ietf.org/html/rfc5988).
 
 > **NOTE:** The link relation identifiers should be unique per resource in the blueprint document.
 
@@ -1165,7 +1317,8 @@ The API Blueprint uses a subset of [RFC6570][rfc6570] to define a resource URI T
 
 ### URI Path Segment
 
-At its simplest form – without any variables – a path segment of an URI Template is identical to an URI path segment:
+At its simplest form – without any variables – a path segment of an 
+URI Template is identical to an URI path segment:
 
 ```
 /path/to/resources/42
@@ -1173,7 +1326,8 @@ At its simplest form – without any variables – a path segment of an URI Temp
 
 ### URI Template Variable
 
-Variable names are case-sensitive. The variable name may consists of following characters **only**:
+Variable names are case-sensitive. The variable name may consists of following
+characters **only**:
 
 - ASCII alpha numeric characters (`a-z`, `A-Z`)
 - Decimal digits (`0-9`)
@@ -1181,11 +1335,14 @@ Variable names are case-sensitive. The variable name may consists of following c
 - [Percent-encoded][pct-encoded] characters
 - `.`
 
-Multiple variables are separated by the comma **without** any leading or trailing spaces. A variable(s) **must** be enclosed in braces – `{}` **without** any additional leading or trailing whitespace.
+Multiple variables are separated by the comma **without** any leading or
+trailing spaces. A variable(s) **must** be enclosed in braces – `{}`
+**without** any additional leading or trailing whitespace.
 
 #### Operators
 
-The first variable in the braces **might** be preceded by an operator. API Blueprint currently supports following operators:
+The first variable in the braces **might** be preceded by an operator. 
+API Blueprint currently supports the following operators:
 
 - `#` – _fragment identifier_ operator
 - `+` – _reserved value_ operator
@@ -1205,7 +1362,8 @@ The first variable in the braces **might** be preceded by an operator. API Bluep
 {&var}
 ```
 
-> **NOTE:** The [explode variable modifier][uri-explode] is also supported. Refer to RFC6570 for its description.
+> **NOTE:** The [explode variable modifier][uri-explode] is also supported.
+> Refer to RFC6570 for its description.
 
 #### Variable Reserved Values
 
@@ -1227,7 +1385,8 @@ With `var := 42` the expansion is `/path/to/resources/42`.
 
 ### Fragment Identifier Variable
 
-URI Template variables for fragment identifiers are defined using the crosshatch (`#`) operator:
+URI Template variables for fragment identifiers are defined using the
+crosshatch (`#`) operator:
 
 ```
 /path/to/resources/42{#var}
@@ -1239,7 +1398,8 @@ With `var := my_id` the expansion is `/path/to/resources/42#my_id`.
 
 ### Variable with Reserved Characters Values
 
-To define URI Template variables with reserved URI characters use the plus (`+`) operator:
+To define URI Template variables with reserved URI characters,
+use the plus (`+`) operator:
 
 ```
 /path/{+var}/42

--- a/Advanced Tutorial.md
+++ b/Advanced Tutorial.md
@@ -1,14 +1,24 @@
 # Advanced API Blueprint Tutorial
 
-Welcome to the advanced API Blueprint tutorial! This tutorial will take you through advanced topics like JSON Schema, request and response attributes, data structures and relation types.
+Welcome to the advanced API Blueprint tutorial! This tutorial will take you
+through advanced topics like JSON Schema, request and response attributes, data
+structures and relation types.
 
 This tutorial assumes that you have read the [API Blueprint Tutorial](https://github.com/apiaryio/api-blueprint/blob/master/Tutorial.md).
 
 ## JSON Schema
 
-Action request and response bodies can have associated schemas that describe the allowed structure of the body content. JSON bodies are typically described with [JSON Schema](http://json-schema.org/). Given a simple JSON response body we can describe the structure of the response with JSON Schema in a `+ Schema` section.
+Action request and response bodies can have associated schemas that describe
+the allowed structure of the body content. JSON bodies are typically described
+with [JSON Schema](http://json-schema.org/). Given a simple JSON response body
+we can describe the structure of the response with JSON Schema in a `+ Schema`
+section.
 
-The schema can describe the type of each member, which members are required, default values, and support a number of other advanced features. Below is an example, taken from the [Polls API](https://raw.github.com/apiaryio/api-blueprint/master/examples/Polls%20API.md) blueprint:
+The schema can describe the type of each member, which members are required,
+default values, and support a number of other advanced features. Below is an
+example, taken from the 
+[Polls API](https://raw.github.com/apiaryio/api-blueprint/master/examples/Polls%20API.md)
+blueprint:
 
 ```apib
 ### Create a New Question [POST]
@@ -49,9 +59,15 @@ containing a question and a collection of answers in the form of choices.
 
 ## Attributes
 
-Another way of describing examples and the structure of your request and response content is by using [MSON](https://github.com/apiaryio/mson#readme). MSON, like API Blueprint, allows you to use human-readable plain text to describe things rather than formats designed for computer parsing like JSON or YAML. Where API Blueprint allows you to describe your API, MSON allows you to describe data structure.
+Another way of describing examples and the structure of your request and
+response content is by using [MSON](https://github.com/apiaryio/mson#readme).
+MSON, like API Blueprint, allows you to use human-readable plain text to
+describe things rather than formats designed for computer parsing like JSON or
+YAML. Where API Blueprint allows you to describe your API, MSON allows you to
+describe data structures.
 
-MSON can be added to resources, actions, and individual requests or responses via an `+ Attributes` section.
+MSON can be added to resources, actions, and individual requests or responses
+via an `+ Attributes` section.
 
 Creating a new question in the polls API can be modeled using MSON:
 
@@ -69,15 +85,24 @@ containing a question and a collection of answers in the form of choices.
 
 ```
 
-When the above blueprint is parsed it will have a JSON body and JSON Schema example generated for it from the MSON attributes. Note, however, that the generated JSON Schema may differ from a hand-written one. In this example, the `minItems` will not be set. If you have such constraints you can override the generated schema by providing your own, in which case only the JSON body will be generated.
+When the above blueprint is parsed it will have a JSON body and JSON Schema
+example generated for it from the MSON attributes. Note, however, that the
+generated JSON Schema may differ from a hand-written one. In this example, the
+`minItems` will not be set. If you have such constraints you can override the
+generated schema by providing your own, in which case only the JSON body will
+be generated.
 
 *Note*: MSON is still considered a beta feature!
 
 ## Data Structures
 
-Once you start using MSON, you may find yourself wanting to reuse certain commonly used or nested data structure components. This is possible with the `## Data Structures` section. Attributes sections can then reference the data structures defined in the Data Structures or other resource sections by name.
+Once you start using MSON, you may find yourself wanting to reuse certain
+commonly used or nested data structure components. This is possible with the
+`## Data Structures` section. Attributes sections can then reference the data
+structures defined in the Data Structures or other resource sections by name.
 
-For example, using the polls API question collection resource, we can split out the `Question` and `Choice` objects:
+For example, using the polls API question collection resource, we can split out
+the `Question` and `Choice` objects:
 
 ```apib
 ### List All Questions [GET]
@@ -102,7 +127,10 @@ For example, using the polls API question collection resource, we can split out 
 
 ## Relation Types
 
-Actions in a blueprint can define a semantic domain-specific meaning by defining a relation type using a `+ Relation` section. This means that an action can have a specific meaning regardless of its URI or name, and allows clients to be built based on the domain of the API rather than specific URIs.
+Actions in a blueprint can define a semantic domain-specific meaning by
+defining a relation type using a `+ Relation` section. This means that an
+action can have a specific meaning regardless of its URI or name, and allows
+clients to be built based on the domain of the API rather than specific URIs.
 
 For example, in the polls API:
 
@@ -119,8 +147,14 @@ For example, in the polls API:
 + Relation: self
 ```
 
-A server or client implementation can now use this information to handle the specific API resource and action URIs. Please see the [Web Linking RFC 5988](https://tools.ietf.org/html/rfc5988) and the [IANA Link Relation Types](http://www.iana.org/assignments/link-relations/link-relations.xhtml) for more information.
+A server or client implementation can now use this information to handle the
+specific API resource and action URIs. Please see the 
+[Web Linking RFC 5988](https://tools.ietf.org/html/rfc5988) and the 
+[IANA Link Relation Types](http://www.iana.org/assignments/link-relations/link-relations.xhtml) for
+more information.
 
 ## Conclusion
 
-This tutorial has covered some advanced API Blueprint topics. For more in-depth information and other advanced topics, please see the [API Blueprint Specification](https://github.com/apiaryio/api-blueprint/blob/master/API%20Blueprint%20Specification.md).
+This tutorial has covered some advanced API Blueprint topics.
+For more in-depth information and other advanced topics,
+please see the [API Blueprint Specification](https://github.com/apiaryio/api-blueprint/blob/master/API%20Blueprint%20Specification.md).

--- a/Glossary of Terms.md
+++ b/Glossary of Terms.md
@@ -12,7 +12,8 @@ Actions are specified by an [HTTP request method](#def-method) within a [resourc
 
 <a name="def-api"></a>
 ### API
-An **HTTP Application programming interface**. Might refer to an API description. See [**API Blueprint**](#def-api-blueprint).
+An **HTTP Application programming interface**. Might refer to an API
+description. See [**API Blueprint**](#def-api-blueprint).
 
 <a name="def-api-blueprint"></a>
 ### API Blueprint
@@ -24,7 +25,9 @@ The **API Blueprint language**. A format used to describe API in an API blueprin
 
 <a name="def-attribute"></a>
 ### Attribute
-Based on the context, attribute (property) of a message-body data structure, or attribute of a resource, or an input attribute of a transition – [Action](#def-action).
+Based on the context, attribute (property) of a message-body data structure, or
+attribute of a resource, or an input attribute of a transition –
+[Action](#def-action).
 
 <a name="def-blueprint"></a>
 ### Blueprint
@@ -32,7 +35,9 @@ An **API description**. A **blueprint file** (or a set of files) that describes 
 
 <a name="def-data-structure"></a>
 ### Data Structure
-A particular data organization, or a description of it. In API Blueprint, data structures and its [Attributes](#def-attribute) are described using the Markdown Syntax for Object Notation – [MSON][].
+A particular data organization, or a description of it. In API Blueprint, data
+structures and their [Attributes](#def-attribute) are described using the
+Markdown Syntax for Object Notation – [MSON][].
 
 <a name="def-entity"></a>
 ### Entity
@@ -65,7 +70,10 @@ An [**URI template**](#def-uri-template) **variable**.
 ### Payload
 An **HTTP transaction message** including its **discussion** and any additional [**assets**](#def-asset) such as entity-body validation schema.
 
-A payload may have its **identifier** – a string for a [request](#def-request) payload or an [HTTP status code](http://en.wikipedia.org/wiki/List_of_HTTP_status_codes) for a [response](#def-response) payload.
+A payload may have an **identifier** – a string for a [request](#def-request)
+payload or an 
+[HTTP status code](http://en.wikipedia.org/wiki/List_of_HTTP_status_codes) for a
+[response](#def-response) payload.
 
 <a name="def-property"></a>
 ### Property
@@ -81,15 +89,21 @@ A [**payload**](#def-payload) containing one specific [HTTP Response](http://www
 
 <a name="def-resource"></a>
 ### Resource
-An API [**resource**](http://www.w3.org/TR/di-gloss/#def-resource) specified by its *URI*. It can also refer to a [**set of resources**](#def-resource) matching one [**URI template**](#def-uri-template).
+An API [**resource**](http://www.w3.org/TR/di-gloss/#def-resource) specified by
+its *URI*. It can also refer to a [**set of resources**](#def-resource)
+matching one [**URI template**](#def-uri-template).
 
 <a name="def-resource-model"></a>
 ### Resource Model
-One [**manifestation of a resource**](http://www.w3.org/TR/di-gloss/#def-resource-manifestation) in the form of a [payload](#def-payload). A resource model is an example representation of its resource. Can be referenced later in the place of a [payload](#def-payload).
+One [**manifestation of a resource**](http://www.w3.org/TR/di-gloss/#def-resource-manifestation) in the
+form of a [payload](#def-payload). A resource model is an example
+representation of its resource. Can be referenced later in the place of a
+[payload](#def-payload).
 
 <a name="def-resource-set"></a>
 ### Resource Set
-A set of API [**resources**](http://www.w3.org/TR/di-gloss/#def-resource) its *URI* matches one specific  [**URI template**](#def-uri-template).
+A set of API [**resources**](http://www.w3.org/TR/di-gloss/#def-resource). Its
+*URI* matches one specific [**URI template**](#def-uri-template).
 
 <a name="def-trait"></a>
 ### Trait

--- a/Tutorial.md
+++ b/Tutorial.md
@@ -1,6 +1,11 @@
 # API Blueprint Tutorial
 
-Welcome to an API Blueprint Tutorial! This tutorial will take you through the basics of the API Blueprint language. We’re going to build an API blueprint step by step for a service called Polls – a simple API allowing consumers to view polls and vote in them. You can take a look at the [full version][Poll API Blueprint] of the blueprint used in this tutorial for reference.
+Welcome to an API Blueprint Tutorial! This tutorial will take you through the
+basics of the API Blueprint language. We’re going to build an API blueprint
+step by step for a service called Polls – a simple API allowing consumers to
+view polls and vote in them. You can take a look at the 
+[full version][Poll API Blueprint] of the blueprint used in this tutorial for
+reference.
 
 > **Note:** **Additional API Blueprint Resources**
 >
@@ -12,7 +17,8 @@ Welcome to an API Blueprint Tutorial! This tutorial will take you through the ba
 
 ## API Blueprint
 
-The first step for creating a blueprint is to specify the API Name and metadata. This step looks as follows:
+The first step for creating a blueprint is to specify the API Name and
+metadata. This step looks as follows:
 
 ```apib
 FORMAT: 1A
@@ -24,17 +30,24 @@ Polls is a simple API allowing consumers to view polls and vote in them.
 
 ## Metadata
 
-The blueprint starts with a metadata section. In this case we have specified that `FORMAT` has the value of `1A`. The format keyword denotes the version of the API Blueprint.
+The blueprint starts with a metadata section. In this case we have specified
+that `FORMAT` has the value of `1A`. The format keyword denotes the version of
+the API Blueprint.
 
 ## API Name & Description
 
-The first heading in the blueprint serves as the name of your API, which in this case is "Polls". Headings start with one or more `#` symbols followed by a title. The API Name here uses one hash to distinguish it as the first level. The number of `#` you use will determine the level of the heading.
+The first heading in the blueprint serves as the name of your API, which in
+this case is "Polls". Headings start with one or more `#` symbols followed by a
+title. The API Name here uses one hash to distinguish it as the first level.
+The number of `#` you use will determine the level of the heading.
 
-Following the heading is a description of the API. You may use further headings to break up the description section.
+Following the heading is a description of the API. You may use further headings
+to break up the description section.
 
 ## Resource Groups
 
-Now it's time to start documenting the API resources. Using the `Group` keyword at the start of a heading, we've created a group of related resources.
+Now it's time to start documenting the API resources. Using the `Group` keyword
+at the start of a heading, we've created a group of related resources.
 
 ```apib
 # Group Questions
@@ -44,7 +57,10 @@ Resources related to questions in the API.
 
 ## Resource
 
-Within the questions resource group, we have a resource called "Question Collection". This resource allows you to view a list of questions. The heading specifies the URI used to access the resource inside of square brackets at the end of the heading.
+Within the questions resource group, we have a resource called "Question
+Collection". This resource allows you to view a list of questions. The heading
+specifies the URI used to access the resource inside of square brackets at the
+end of the heading.
 
 ```apib
 ## Question Collection [/questions]
@@ -53,14 +69,17 @@ Within the questions resource group, we have a resource called "Question Collect
 ### Actions
 
 API Blueprint allows you to specify each action you may make on a resource. An
-action is specified with a sub-heading inside of a resource with the name of the
-action followed by the HTTP method.
+action is specified with a sub-heading inside of a resource with the name of
+the action followed by the HTTP method.
 
 ```apib
 ### List All Questions [GET]
 ```
 
-An action should include at least one response from the server which must include a status code and may contain a body. A response is defined as a list item within an action. Lists are created by preceding list items with either a `+`, `*` or `-`.
+An action should include at least one response from the server which must
+include a status code and may contain a body. A response is defined as a list
+item within an action. Lists are created by preceding list items with either a
+`+`, `*` or `-`.
 
 This action returns a `200` status code along with a JSON body.
 
@@ -95,9 +114,13 @@ This action returns a `200` status code along with a JSON body.
         ]
 ```
 
-> **Note:** Specifying the media type after the response status code generates a `Content-Type` HTTP header. You do not have to explicitly specify the `Content-Type` header.
+> **Note:** Specifying the media type after the response status code generates
+> a `Content-Type` HTTP header. You do not have to explicitly specify the
+> `Content-Type` header.
 
-The polls resource has a second action which allows you to create a new question. This action includes a description showing the structure you would send to the server to perform this action.
+The polls resource has a second action which allows you to create a new
+question. This action includes a description showing the structure you would
+send to the server to perform this action.
 
 ```apib
 ### Create a New Question [POST]
@@ -170,25 +193,31 @@ The next resource is “Question”, which represents a single question.
 
 ### URI Template
 
-The URI for the “Question” resource uses a variable component, expressed by [URI Template][]. In this case, there is an ID variable called `question_id`, represented in the URI template as `{question_id}`.
+The URI for the “Question” resource uses a variable component, expressed by
+[URI Template][]. In this case, there is an ID variable called `question_id`,
+represented in the URI template as `{question_id}`.
 
 <a id="uri-parameters"></a>
 ### URI Parameters
 
-URI parameters should describe  the URI using a list of Parameters. For “Question” it would be as follows:
+URI parameters should describe the URI using a list of Parameters. For
+“Question” it would be as follows:
 
 ```apib
 + Parameters
     + question_id (number) - ID of the Question in the form of an integer
 ```
 
-The `question_id` variable of the URI template is a parameter for every action on this resource. It's defined here using an arbitrary type `number`, followed by a description for the parameter.
+The `question_id` variable of the URI template is a parameter for every action
+on this resource. It's defined here using an arbitrary type `number`, followed
+by a description for the parameter.
 
-> Refer to API Blueprint Specification's [URI Parameters Section][] for more examples.
+> Refer to API Blueprint Specification's [URI Parameters Section][] for more
+> examples.
 
 ### Actions
 
-This resource has an action to retrieve the questions detail.
+This resource has an action to retrieve the question's detail.
 
 ```apib
 ### View a Questions Detail [GET]
@@ -223,7 +252,8 @@ This resource has an action to retrieve the questions detail.
 
 #### Response Without a Body
 
-This resource has a delete action. The server will return a 204 response without a body.
+This resource has a delete action. The server will return a 204 response
+without a body.
 
 ```apib
 ### Delete [DELETE]
@@ -233,13 +263,18 @@ This resource has a delete action. The server will return a 204 response without
 
 ## Complete Blueprint
 
-You can find an [implementation](http://github.com/apiaryio/polls-api) of this API at http://polls.apiblueprint.org/ along with the complete [Poll API Blueprint][] in the [API Blueprint Examples][] repository. You can also enjoy it [rendered on Apiary][].
+You can find an [implementation](http://github.com/apiaryio/polls-api) of this
+API at http://polls.apiblueprint.org/ along with the complete 
+[Poll API Blueprint][] in the [API Blueprint Examples][] repository. You can
+also enjoy it [rendered on Apiary][].
 
-> **Note:** Take a look at the [API Blueprint Glossary of Terms][] if you need clarification of some of the terms used though this document.
+> **Note:** Take a look at the [API Blueprint Glossary of Terms][] if you need
+> clarification of some of the terms used though this document.
 
 ## API Blueprint Tools
 
-Visit the [Tooling Section][] of [apiblueprint.org][] to find tools to use with API Blueprints.
+Visit the [Tooling Section][] of [apiblueprint.org][] to find tools to use with
+API Blueprints.
 
 [GitHub Gists]:                     https://gist.github.com
 [API Blueprint Glossary of Terms]:  https://github.com/apiaryio/api-blueprint/blob/master/Glossary%20of%20Terms.md

--- a/examples/01. Simplest API.md
+++ b/examples/01. Simplest API.md
@@ -1,12 +1,20 @@
 FORMAT: 1A
 
 # The Simplest API
-This is one of the simplest APIs written in the **API Blueprint**.
-One plain resource combined with a method and that's it! We will explain what is going on in the next installment - [Resource and Actions](02.%20Resource%20and%20Actions.md).
+This is one of the simplest APIs written in the **API Blueprint**. One plain
+resource combined with a method and that's it! We will explain what is going on
+in the next installment - 
+[Resource and Actions](02.%20Resource%20and%20Actions.md).
 
-**Note:** As we progress through the examples, do not also forget to view the [Raw](https://raw.github.com/apiaryio/api-blueprint/master/examples/01.%20Simplest%20API.md) code to see what is really going on in the API Blueprint, as opposed to just seeing the output of the Github Markdown parser.
+**Note:** As we progress through the examples, do not also forget to view the
+[Raw](https://raw.github.com/apiaryio/api-blueprint/master/examples/01.%20Simplest%20API.md)
+code to see what is really going on in the API Blueprint, as opposed to just
+seeing the output of the Github Markdown parser.
 
-Also please keep in mind that every single example in this course is a **real API Blueprint** and as such you can **parse** it with the [API Blueprint parser](https://github.com/apiaryio/drafter) or one of its [bindings](https://github.com/apiaryio/drafter#bindings).
+Also please keep in mind that every single example in this course is a **real
+API Blueprint** and as such you can **parse** it with the 
+[API Blueprint parser](https://github.com/apiaryio/drafter) or one of its
+[bindings](https://github.com/apiaryio/drafter#bindings).
 
 ## API Blueprint
 + [This: Raw API Blueprint](https://raw.github.com/apiaryio/api-blueprint/master/examples/01.%20Simplest%20API.md)

--- a/examples/02. Resource and Actions.md
+++ b/examples/02. Resource and Actions.md
@@ -9,21 +9,32 @@ This API example demonstrates how to define a resource with multiple actions.
 + [Next: Named Resource and Actions](03.%20Named%20Resource%20and%20Actions.md)
 
 # /message
-This is our [resource](http://www.w3.org/TR/di-gloss/#def-resource). It is defined by its [URI](http://www.w3.org/TR/di-gloss/#def-uniform-resource-identifier) or, more precisely, by its [URI Template](http://tools.ietf.org/html/rfc6570).
+This is our [resource](http://www.w3.org/TR/di-gloss/#def-resource). It is
+defined by its
+[URI](http://www.w3.org/TR/di-gloss/#def-uniform-resource-identifier) or, more
+precisely, by its [URI Template](http://tools.ietf.org/html/rfc6570).
 
 This resource has no actions specified but we will fix that soon.
 
 ## GET
 Here we define an action using the `GET` [HTTP request method](http://www.w3schools.com/tags/ref_httpmethods.asp) for our resource `/message`.
 
-As with every good action it should return a [response](http://www.w3.org/TR/di-gloss/#def-http-response). A response always bears a status code. Code 200 is great as it means all is green. Responding with some data can be a great idea as well so let's add a plain text message to our response.
+As with every good action it should return a
+[response](http://www.w3.org/TR/di-gloss/#def-http-response). A response always
+bears a status code. Code 200 is great as it means all is green. Responding
+with some data can be a great idea as well so let's add a plain text message to
+our response.
 
 + Response 200 (text/plain)
 
         Hello World!
 
 ## PUT
-OK, let's add another action. This time to put new data to our resource (essentially an update action). We will need to send something in a [request](http://www.w3.org/TR/di-gloss/#def-http-request) and then send a response back confirming the posting was a success (HTTP Status Code 204 ~ Resource updated successfully, no content is returned).
+OK, let's add another action. This time to put new data to our resource
+(essentially an update action). We will need to send something in a
+[request](http://www.w3.org/TR/di-gloss/#def-http-request) and then send a
+response back confirming the posting was a success (_HTTP Status Code 204 ~
+Resource updated successfully, no content is returned_).
 
 + Request (text/plain)
 

--- a/examples/03. Named Resource and Actions.md
+++ b/examples/03. Named Resource and Actions.md
@@ -1,7 +1,8 @@
 FORMAT: 1A
 
 # Named Resource and Actions API
-This API example demonstrates how to name a resource and its actions, to give the reader a better idea about what the resource is used for.
+This API example demonstrates how to name a resource and its actions, to give
+the reader a better idea about what the resource is used for.
 
 ## API Blueprint
 + [Previous: Resource and Actions](02.%20Resource%20and%20Actions.md)
@@ -9,10 +10,12 @@ This API example demonstrates how to name a resource and its actions, to give th
 + [Next: Grouping Resources](04.%20Grouping%20Resources.md)
 
 # My Message [/message]
-OK, `My Message` probably isn't the best name for our resource but it will do for now. Note the URI `/message` is enclosed in square brackets.
+OK, `My Message` probably isn't the best name for our resource but it will do
+for now. Note the URI `/message` is enclosed in square brackets.
 
 ## Retrieve a Message [GET]
-Now this is informative! No extra explanation needed here. This action clearly retrieves the message.
+Now this is informative! No extra explanation needed here. This action clearly
+retrieves the message.
 
 + Response 200 (text/plain)
 

--- a/examples/04. Grouping Resources.md
+++ b/examples/04. Grouping Resources.md
@@ -1,7 +1,9 @@
 FORMAT: 1A
 
 # Grouping Resources API
-This API example demonstrates how to group resources and form **groups of resources**. You can create as many or as few groups as you like. If you do not create any group all your resources will be part of an "unnamed" group.
+This API example demonstrates how to group resources and form **groups of
+resources**. You can create as many or as few groups as you like. If you do not
+create any group all your resources will be part of an "unnamed" group.
 
 ## API Blueprint
 + [Previous: Named Resource and Actions](03.%20Named%20Resource%20and%20Actions.md)
@@ -11,9 +13,12 @@ This API example demonstrates how to group resources and form **groups of resour
 # Group Messages
 Group of all messages-related resources.
 
-This is the first group of resources in this document. It is **recognized** by the **keyword `group`** and its name is `Messages`.
+This is the first group of resources in this document. It is **recognized** by
+the **keyword `group`** and its name is `Messages`.
 
-Any following resource definition is considered to be a part of this group until another group is defined. It is **customary** to increase header level of resources (and actions) nested under a resource.
+Any following resource definition is considered to be a part of this group
+until another group is defined. It is **customary** to increase header level of
+resources (and actions) nested under a resource.
 
 ## My Message [/message]
 
@@ -34,4 +39,5 @@ Any following resource definition is considered to be a part of this group until
 # Group Users
 Group of all user-related resources.
 
-This is the second group in this blueprint. For now, no resources were defined here and as such we will omit it from the next installement of this course.
+This is the second group in this blueprint. For now, no resources were defined
+here and as such we will omit it from the next installment of this course.

--- a/examples/05. Responses.md
+++ b/examples/05. Responses.md
@@ -1,7 +1,9 @@
 FORMAT: 1A
 
 # Responses API
-In this API example we will discuss what information a response can bear and how to define multiple responses. Technically a response is represented by a payload that is sent back in response to a request.
+In this API example we will discuss what information a response can bear and
+how to define multiple responses. Technically a response is represented by a
+payload that is sent back in response to a request.
 
 ## API Blueprint
 + [Previous: Grouping Resources](04.%20Grouping%20Resources.md)
@@ -14,7 +16,12 @@ Group of all messages-related resources.
 ## My Message [/message]
 
 ### Retrieve a Message [GET]
-This action has **two** responses defined: One returing a plain text and the other a JSON representation of our resource. Both has the same HTTP status code. Also both responses bear additional information in the form of a custom HTTP header. Note that both responses have set the `Content-Type` HTTP header just by specifying `(text/plain)` or `(application/json)` in their respective signatures.
+This action has **two** responses defined: One returning plain text and the
+other a JSON representation of our resource. Both have the same HTTP status
+code. Also both responses bear additional information in the form of a custom
+HTTP header. Note that both responses have set the `Content-Type` HTTP header
+just by specifying `(text/plain)` or `(application/json)` in their respective
+signatures.
 
 + Response 200 (text/plain)
 

--- a/examples/06. Requests.md
+++ b/examples/06. Requests.md
@@ -1,7 +1,9 @@
 FORMAT: 1A
 
 # Requests API
-Following the [Responses](05.%20Responses.md) example, this API will show you how to define multiple requests and what data these requests can bear. Let's demonstrate multiple requests on a trivial example of content negotiation.
+Following the [Responses](05.%20Responses.md) example, this API will show you
+how to define multiple requests and what data these requests can bear. Let's
+demonstrate multiple requests on a trivial example of content negotiation.
 
 ## API Blueprint
 + [Previous: Responses](05.%20Responses.md)
@@ -14,7 +16,11 @@ Group of all messages-related resources.
 ## My Message [/message]
 
 ### Retrieve a Message [GET]
-In API Blueprint requests can hold exactly the same kind of information and can be described by exactly the same structure as responses, only with different signature – using the `Request` keyword. The string that follows after the `Request` keyword is a request identifier. Again, using an explanatory and simple naming is the best way to go.
+In API Blueprint, _requests_ can hold exactly the same kind of information and
+can be described using exactly the same structure as _responses_, only with
+different signature – using the `Request` keyword. The string that follows
+after the `Request` keyword is a request identifier. Again, using explanatory
+and simple naming is the best way to go.
 
 + Request Plain Text Message
 

--- a/examples/07. Parameters.md
+++ b/examples/07. Parameters.md
@@ -3,7 +3,9 @@ FORMAT: 1A
 # Parameters API
 In this installment of the API Blueprint course we will discuss how to describe URI parameters.
 
-But first let's add more messages to our system. For that we would need introduce an message identifier – id. This id will be our parameter when communicating with our API about messages.
+But first let's add more messages to our system. For that we would need
+introduce an message identifier – id. This id will be our parameter when
+communicating with our API about messages.
 
 ## API Blueprint
 + [Previous: Requests](06.%20Requests.md)
@@ -14,8 +16,11 @@ But first let's add more messages to our system. For that we would need introduc
 Group of all messages-related resources.
 
 ## My Message [/message/{id}]
-Here we have added the message `id` parameter as an [URI Template variable](http://tools.ietf.org/html/rfc6570) in the Message resource's URI.
-Note the parameter name `id` is enclosed in curly brackets. We will discuss this parameter in the `Parameters` section below, where we will also set its example value to `1` and declare it of an arbitrary 'number' type.
+Here we have added the message `id` parameter as an 
+[URI Template variable](http://tools.ietf.org/html/rfc6570) in the Message
+resource's URI. Note the parameter name `id` is enclosed in curly brackets. We
+will discuss this parameter in the `Parameters` section below, where we will
+also set its example value to `1` and declare it of an arbitrary 'number' type.
 
 + Parameters
 
@@ -73,7 +78,10 @@ Note the parameter name `id` is enclosed in curly brackets. We will discuss this
 ## All My Messages [/messages{?limit}]
 A resource representing all of my messages in the system.
 
-We have added the query URI template parameter - `limit`. This parameter is used for limiting the number of results returned by some actions on this resource. It does not affect every possible action of this resource therefore we will discuss it only at the particular action level below.
+We have added the query URI template parameter - `limit`. This parameter is
+used for limiting the number of results returned by some actions on this
+resource. It does not affect every possible action of this resource, therefore
+we will discuss it only at the particular action level below.
 
 ### Retrieve all Messages [GET]
 

--- a/examples/08. Attributes.md
+++ b/examples/08. Attributes.md
@@ -1,9 +1,13 @@
 FORMAT: 1A
 
 # Attributes API
-This API example demonstrates how to describe body attributes of a request or response message.
+This API example demonstrates how to describe body attributes of a request or
+response message.
 
-In this case, the description is complementary (and duplicate!) to the provided JSON example in the body section. The [Advanced Attributes](09.%20Advanced%20Attributes.md) API example will demonstrate how to avoid duplicates and how to reuse attributes descriptions.
+In this case, the description is complementary (and duplicate!) to the provided
+JSON example in the body section. The 
+[Advanced Attributes](09.%20Advanced%20Attributes.md) API example will
+demonstrate how to avoid duplicates and how to reuse attribute descriptions.
 
 ## API Blueprint
 + [Previous: Parameters](07.%20Parameters.md)
@@ -13,7 +17,8 @@ In this case, the description is complementary (and duplicate!) to the provided 
 # Group Coupons
 
 ## Coupon [/coupons/{id}]
-A coupon contains information about a percent-off or amount-off discount you might want to apply to a customer.
+A coupon contains information about a percent-off or amount-off discount you
+might want to apply to a customer.
 
 ### Retrieve a Coupon [GET]
 Retrieves the coupon with the given ID.
@@ -25,7 +30,8 @@ Retrieves the coupon with the given ID.
         + created: 1415203908 (number) - Time stamp
         + percent_off: 25 (number)
 
-            A positive integer between 1 and 100 that represents the discount the coupon will apply.
+            A positive integer between 1 and 100 that represents the discount
+            the coupon will apply.
 
         + redeem_by (number) - Date after which the coupon can no longer be redeemed
 

--- a/examples/09. Advanced Attributes.md
+++ b/examples/09. Advanced Attributes.md
@@ -1,13 +1,23 @@
 FORMAT: 1A
 
 # Advanced Attributes API
-Improving the previous [Attributes](08.%20Attributes.md) description example, this API example describes the `Coupon` resource attributes (data structure) regardless of the serialization format. These attributes can be later referenced using the resource name
+Improving the previous [Attributes](08.%20Attributes.md) description example,
+this API example describes the `Coupon` resource attributes (data structure)
+regardless of the serialization format. These attributes can be later
+referenced using the resource name.
 
-These attributes are then reused in the `Retrieve a Coupon` action. Since they describe the complete message, no explicit JSON body example is needed.
+These attributes are then reused in the `Retrieve a Coupon` action. Since they
+describe the complete message, no explicit JSON body example is needed.
 
-Moving forward, the `Coupon` resource data structure is then reused when defining the attributes of the coupons collection resource – `Coupons`.
+Moving forward, the `Coupon` resource data structure is then reused when
+defining the attributes of the coupons collection resource – `Coupons`.
 
-The `Create a Coupon` action also demonstrate the description of request attributes – once defined, these attributes are implied on every `Create a Coupon` request unless the request specifies otherwise. Apparently, the description of action attributes is somewhat duplicate to the definition of `Coupon` resource attributes. We will address this in the next [Data Structures](10.%20Data%20Structures.md) example.
+The `Create a Coupon` action also demonstrate the description of request
+attributes – once defined, these attributes are implied on every `Create a
+Coupon` request unless the request specifies otherwise. Apparently, the
+description of action attributes is somewhat duplicate to the definition of
+`Coupon` resource attributes. We will address this in the next 
+[Data Structures](10.%20Data%20Structures.md) example.
 
 ## API Blueprint
 + [Previous: Attributes](08.%20Attributes.md)
@@ -17,7 +27,8 @@ The `Create a Coupon` action also demonstrate the description of request attribu
 # Group Coupons
 
 ## Coupon [/coupons/{id}]
-A coupon contains information about a percent-off or amount-off discount you might want to apply to a customer.
+A coupon contains information about a percent-off or amount-off discount you
+might want to apply to a customer.
 
 + Parameters
     + id (string)
@@ -49,7 +60,8 @@ Returns a list of your coupons.
 + Parameters
     + limit (number, optional)
 
-        A limit on the number of objects to be returned. Limit can range between 1 and 100 items.
+        A limit on the number of objects to be returned. Limit can range
+        between 1 and 100 items.
 
         + Default: `10`
 

--- a/examples/10. Data Structures.md
+++ b/examples/10. Data Structures.md
@@ -1,9 +1,14 @@
 FORMAT: 1A
 
 # Data Structures API
-Following [Advanced Attributes](09.%20Advanced%20Attributes.md), this example demonstrates defining arbitrary data structure to be reused by various attribute descriptions.
+Following [Advanced Attributes](09.%20Advanced%20Attributes.md), this example
+demonstrates defining arbitrary data structure to be reused by various
+attribute descriptions.
 
-Since a portion of the `Coupon` data structure is shared between the `Coupon` definition itself and the `Create a Coupon` action, it was separated into a `Coupon Base` data structure in the `Data Structures` API Blueprint Section. Doing so enables us to reuse it as a base-type of other attribute definitions.
+Since a portion of the `Coupon` data structure is shared between the `Coupon`
+definition itself and the `Create a Coupon` action, it was separated into a
+`Coupon Base` data structure in the `Data Structures` API Blueprint Section.
+Doing so enables us to reuse it as a base-type of other attribute definitions.
 
 ## API Blueprint
 + [Previous: Advanced Attributes](09.%20Advanced%20Attributes.md)
@@ -13,7 +18,8 @@ Since a portion of the `Coupon` data structure is shared between the `Coupon` de
 # Group Coupons
 
 ## Coupon [/coupons/{id}]
-A coupon contains information about a percent-off or amount-off discount you might want to apply to a customer.
+A coupon contains information about a percent-off or amount-off discount you
+might want to apply to a customer.
 
 + Parameters
     + id (string)
@@ -40,7 +46,8 @@ Returns a list of your coupons.
 + Parameters
     + limit (number, optional)
 
-        A limit on the number of objects to be returned. Limit can range between 1 and 100 items.
+        A limit on the number of objects to be returned. Limit can range
+        between 1 and 100 items.
 
         + Default: `10`
 
@@ -62,6 +69,7 @@ Creates a new Coupon.
 ## Coupon Base (object)
 + percent_off: 25 (number)
 
-    A positive integer between 1 and 100 that represents the discount the coupon will apply.
+    A positive integer between 1 and 100 that represents the discount the
+    coupon will apply.
 
 + redeem_by (number) - Date after which the coupon can no longer be redeemed

--- a/examples/11. Resource Model.md
+++ b/examples/11. Resource Model.md
@@ -1,9 +1,16 @@
 FORMAT: 1A
 
 # Resource Model API
-Resource model is a [resource manifestation](http://www.w3.org/TR/di-gloss/#def-resource-manifestation). One particular representation of your resource.
+Resource model is a [resource manifestation](http://www.w3.org/TR/di-gloss/#def-resource-manifestation).
+One particular representation of your resource.
 
-Furthermore, in API Blueprint, any `resource model` you have defined can be referenced in a request or response section, saving you lots of time maintaining your API blueprint. You simply define a resource model as any payload (e. g. [request](https://github.com/apiaryio/api-blueprint/blob/master/examples/06.%20Requests.md) or [response](https://github.com/apiaryio/api-blueprint/blob/master/examples/5.%20Responses.md)) and then reference it later where you would normally write a `request` or `response`.
+Furthermore, in API Blueprint, any `resource model` you have defined can be
+referenced in a request or response section, saving you lots of time
+maintaining your API blueprint. You simply define a resource model as any
+payload (e.g. [request](https://github.com/apiaryio/api-blueprint/blob/master/examples/06.%20Requests.md)
+or [response](https://github.com/apiaryio/api-blueprint/blob/master/examples/5.%20Responses.md))
+and then reference it later where you would normally write a `request` or
+`response`.
 
 ## API Blueprint
 + [Previous: Data Structures](10.%20Data%20Structures.md)
@@ -36,7 +43,8 @@ Group of all messages-related resources.
             }
 
 ### Retrieve a Message [GET]
-At this point we will utilize our `Message` resource model and reference it in `Response 200`.
+At this point we will utilize our `Message` resource model and reference it in
+`Response 200`.
 
 + Response 200
 

--- a/examples/12. Advanced Action.md
+++ b/examples/12. Advanced Action.md
@@ -1,7 +1,8 @@
 FORMAT: 1A
 
 # Advanced Action API
-A resource action is – in fact – a state transition. This API example demonstrates an action - state transition - to another resource.
+A resource action is – in fact – a state transition. This API example
+demonstrates an action - state transition - to another resource.
 
 ## API Blueprint
 + [Previous: Resource Model](11.%20Resource%20Model.md)
@@ -34,7 +35,7 @@ A resource action is – in fact – a state transition. This API example demons
         ]
 
 ## Retrieve Task [GET /task/{id}]
-This is a state transition to another resource
+This is a state transition to another resource.
 
 + Parameters
     + id (string)

--- a/examples/14. JSON Schema.md
+++ b/examples/14. JSON Schema.md
@@ -1,7 +1,9 @@
 FORMAT: 1A
 
 # JSON Schema
-Every request and response can have a schema. Below you will find examples using [JSON Schema](http://json-schema.org/) to describe the format of request and response body content.
+Every request and response can have a schema. Below you will find examples
+using [JSON Schema](http://json-schema.org/) to describe the format of request
+and response body content.
 
 ## API Blueprint
 + [Previous: Named Endpoints](13.%20Named%20Endpoints.md)
@@ -55,7 +57,8 @@ Gets a single note by its unique identifier.
             }
 
 ## Update a note [PATCH]
-Modify a note's data using its unique identifier. You can edit the `title`, `content`, and `tags`.
+Modify a note's data using its unique identifier. You can edit the `title`,
+`content`, and `tags`.
 
 + Request (application/json)
 

--- a/examples/15. Advanced JSON Schema.md
+++ b/examples/15. Advanced JSON Schema.md
@@ -1,7 +1,10 @@
 FORMAT: 1A
 
 # Advanced JSON Schema
-The JSON body and JSON Schema for a request or response can be generated from the attributes section MSON data structure. The generated schema can also be overridden by providing an explicit schema, as you can see in the examples below.
+The JSON body and JSON Schema for a request or response can be generated from
+the attributes section MSON data structure. The generated schema can also be
+overridden by providing an explicit schema, as you can see in the examples
+below.
 
 ## API Blueprint
 + [Previous: JSON Schema](14.%20JSON%20Schema.md)
@@ -26,7 +29,8 @@ Gets a single note by its unique identifier.
         + tags: todo, home (array[string])
 
 ## Update a note [PATCH]
-Modify a note's data using its unique identifier. You can edit the `title`, `content`, and `tags`.
+Modify a note's data using its unique identifier. You can edit the `title`,
+`content`, and `tags`.
 
 + Request (application/json)
 

--- a/examples/Real World API.md
+++ b/examples/Real World API.md
@@ -2,7 +2,8 @@ FORMAT: 1A
 HOST: https://alpha-api.app.net
 
 # Real World API
-This API Blueprint demonstrates a real world example documenting a portion of [App.net API](http://developers.app.net).
+This API Blueprint demonstrates a real world example documenting a portion of
+[App.net API](http://developers.app.net).
 
 NOTE: This document is a **work in progress**.
 
@@ -10,7 +11,9 @@ NOTE: This document is a **work in progress**.
 This section groups App.net post resources.
 
 ## Post [/stream/0/posts/{post_id}]
-A Post is the other central object utilized by the App.net Stream API. It has rich text and annotations which comprise all of the content a users sees in their feed. Posts are closely tied to the follow graph...
+A Post is the other central object utilized by the App.net Stream API. It has
+rich text and annotations which comprise all of the content a users sees in
+their feed. Posts are closely tied to the follow graph...
 
 + Parameters
     + post_id: `1` (string) - The id of the Post.
@@ -74,7 +77,8 @@ Returns a specific Post.
     [Post][]
 
 ### Delete a Post [DELETE]
-Delete a Post. The current user must be the same user who created the Post. It returns the deleted Post on success.
+Delete a Post. The current user must be the same user who created the Post. It
+returns the deleted Post on success.
 
 + Response 204
 
@@ -106,7 +110,8 @@ A Collection of posts.
     ```
 
 ### Create a Post [POST]
-Create a new Post object. Mentions and hashtags will be parsed out of the post text, as will bare URLs...
+Create a new Post object. Mentions and hashtags will be parsed out of the post
+text, as will bare URLs...
 
 + Request
 
@@ -124,13 +129,15 @@ Retrieves all posts.
     [Posts Collection][]
 
 ## Stars [/stream/0/posts/{post_id}/star]
-A User’s stars are visible to others, but they are not automatically added to your followers’ streams.
+A User’s stars are visible to others, but they are not automatically added to
+your followers’ streams.
 
 + Parameters
     + post_id: `1` (string) - The id of the Post.
 
 ### Star a Post [POST]
-Save a given Post to the current User’s stars. This is just a “save” action, not a sharing action.
+Save a given Post to the current User’s stars. This is just a “save” action,
+not a sharing action.
 
 *Note: A repost cannot be starred. Please star the parent Post.*
 


### PR DESCRIPTION
Wrap lines, it's more suited to a plaintext format like markdown.

For rendering, paragraphs don't _need_ to be wrapped. But markdown uses
a double-linebreak as paragraph separator so that paragraphs _can_ be
wrapped. As Gruber writes:

>  Readability, however, is emphasized above all else. A
    Markdown-formatted document should be publishable as-is, as plain
    text, without looking like it’s been marked up with tags or
    formatting instructions.

For me, this includes wrapping lines. A lot of source code, such as
C or javascript, doesn't need wrapping either. But yet we do, for
readability and better diffs.

Here's a markdown style guide that raises the same points (both pro
and con):
http://www.cirosantilli.com/markdown-style-guide/#line-wrapping