### PR TITLE
Fix intra-README link to contribution section

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ achieve the goals be it API development, governance or delivery.
 API Blueprint is completely open sourced under the MIT license.
 Any [contribution][contribute] is highly appreciated.
 
-[contribute]: #Contribute
+[contribute]: #contribute
 
 ## At home on GitHub
 API Blueprint language is recognized by GitHub. You can


### PR DESCRIPTION
The anchor generated for sections during Markdown processing is all lowercase 😃 