### PR TITLE
feat: Action identifiers can contain any characters

### DIFF
--- a/API Blueprint Specification.md
+++ b/API Blueprint Specification.md
@@ -739,16 +739,16 @@ Defined by an [HTTP request method][httpmethods]:
 
 **-- or --**
 
-Defined by an action [name (identifier)](#def-identifier) followed by an 
-[HTTP request method][httpmethods] enclosed in square brackets `[]`.
+Defined by an action name (identifier) followed by an [HTTP request
+method][httpmethods] enclosed in square brackets `[]`.
 
     ## <identifier> [<HTTP request method>]
 
 **-- or --**
 
-Defined by an action [name (identifier)](#def-identifier) followed by an 
-[HTTP request method][httpmethods] and 
-[URI template][uritemplate] enclosed in square brackets `[]`.
+Defined by an action name (identifier) followed by an [HTTP request
+method][httpmethods] and [URI template][uritemplate] enclosed in square
+brackets `[]`.
 
     ## <identifier> [<HTTP request method> <URI template>]
 


### PR DESCRIPTION
Please see https://github.com/apiaryio/snowcrash/pull/426 for more justification for these changes. I've removed the hyperlinking from action identifiers to the identifier section as these identifiers are no longer subject to these rules after https://github.com/apiaryio/snowcrash/pull/426.